### PR TITLE
fix: move links to https instead of http

### DIFF
--- a/src/main/asciidoc/docinfo.html
+++ b/src/main/asciidoc/docinfo.html
@@ -205,7 +205,7 @@
         font: 0/0 a;
         text-shadow: none;
         color: transparent;
-        background: url("http://gravitee.io/images/logo.png") no-repeat center;
+        background: url("https://gravitee.io/images/logo.png") no-repeat center;
         -moz-transition: all 0.5s ease-in-out;
         -o-transition: all 0.5s ease-in-out;
         -webkit-transition: all 0.5s ease-in-out;

--- a/src/main/asciidoc/index-docinfo.html
+++ b/src/main/asciidoc/index-docinfo.html
@@ -2,7 +2,7 @@
     <a href="https://github.com/gravitee-io"><img style="position: absolute; top: 0; right: 0; border: 0;" src="https://camo.githubusercontent.com/652c5b9acfaddf3a9c326fa6bde407b87f7be0f4/68747470733a2f2f73332e616d617a6f6e6177732e636f6d2f6769746875622f726962626f6e732f666f726b6d655f72696768745f6f72616e67655f6666373630302e706e67" alt="Fork me on GitHub" data-canonical-src="https://s3.amazonaws.com/github/ribbons/forkme_right_orange_ff7600.png"></a>
     <div class="row">
         <div class="logo">
-            <a href="http://gravitee.io">Gravitee.io</a>
+            <a href="https://gravitee.io">Gravitee.io</a>
         </div>
 
         <nav id="main-nav-wrap">


### PR DESCRIPTION
fix gravitee-io/issues#3