### PR TITLE
feat(oauth2) : add oauth2 authentication documentation

### DIFF
--- a/src/main/asciidoc/installation-guide/installation-guide-configuration.adoc
+++ b/src/main/asciidoc/installation-guide/installation-guide-configuration.adoc
@@ -5,6 +5,7 @@ Gravitee.io allows you to externalize your configuration via the `gravitee.yml` 
 
 * How to configure <<gravitee-standalone-gateway-configuration, Gravitee.io Gateway>>
 * How to configure <<gravitee-standalone-management-configuration, Gravitee.io Management API>>
+* How to configure <<gravitee-standalone-management-ui-configuration, Gravitee.io Web UI>>
 * How to configure <<gravitee-repository-mongodb-configuration, Gravitee.io Repositories>>
 
 [[gravitee-standalone-gateway-configuration]]
@@ -644,6 +645,7 @@ security:
   oauth.endpoint.check_token: # OAuth2 token validation endpoint url
   oauth.client.id: # OAuth2 resource server client id
   oauth.client.secret: # OAut2 resource server client secret
+  oauth.administrators: # Gravitee.io administrators, you can declare multiple administrators with comma separator
 ----
 
 NOTE: With OAuth2 Authentication type, all requests to Gravitee Management API must contain the following header : Authorization Bearer <your-access-token>
@@ -838,6 +840,34 @@ ds:
     host: localhost
     port: 9300
 ----
+
+[[gravitee-standalone-management-ui-configuration]]
+=== Web UI Settings
+
+Gravitee.io Web UI configuration is done via the `constant.js` file that can be found under `GRAVITEE_UI_HOME` folder.
+
+[source,bash]
+[subs="attributes"]
+$ cd graviteeio-management-ui-{graviteeio-management-ui-version}
+$ vi constants.js
+
+[source,javascript]
+[subs="attributes"]
+'use strict';
+angular.module('gvConstants', []).constant('Constants', {
+  // if the management REST API is on a different domain, put something like: http://[api-rest-domain]/management/
+  "baseURL": '/management/',
+  // Web UI version
+  "version": "{graviteeio-management-ui-version}"
+  // Security configuration
+  "securityType": "oauth2", // default value is "basic"
+  // oauth2 authorization server url
+  "oauth2ServerURL": "http://oauth-server-url",
+  // oauth2 client id for the authorization implicit grant flow
+  "oauth2ClientId": "client-id"
+});
+
+NOTE: Gravitee.io use the https://tools.ietf.org/html/rfc6749#section-4.2[OAuth2 Implicit Flow] to handle user authentication. Make sure your OAuth2 client grant types are authorized to use this grant flow.
 
 [[gravitee-repositories-configuration]]
 === Advanced Repositories Settings

--- a/src/main/asciidoc/installation-guide/installation-guide-management-webui.adoc
+++ b/src/main/asciidoc/installation-guide/installation-guide-management-webui.adoc
@@ -43,21 +43,3 @@ With Node::
 $ npm install http-server -g
 $ cd graviteeio-management-ui-{graviteeio-management-ui-version}
 $ http-server
-
-==== Configuration
-
-The Management UI provides a UI to the Gravitee.io Management API to manage the platform globally. The only one thing to configure is the Gravitee.io Management API URL :
-
-[source,bash]
-[subs="attributes"]
-$ cd graviteeio-management-ui-{graviteeio-management-ui-version}
-$ vi constants.js
-
-[source,javascript]
-[subs="attributes"]
-'use strict';
-angular.module('gvConstants', []).constant('Constants', {
-  // if the management REST API is on a different domain, put something like: http://[api-rest-domain]/management/
-  "baseURL": '/management/',
-  "version": "0.8.2"
-});


### PR DESCRIPTION
Complete documentation for the oauth2 authentication mode for both Management REST API and Management Web UI.

This closes gravitee-io/issues#100
