### PR TITLE
Minor modification to UI installation guide to reiterate that baseURL has to be properly configured

### DIFF
--- a/pages/apim/installation-guide/installation-guide-management-webui.adoc
+++ b/pages/apim/installation-guide/installation-guide-management-webui.adoc
@@ -56,12 +56,14 @@ $ vi constants.js
 
 [source,javascript]
 [subs="attributes"]
-'use strict';
-angular.module('gvConstants', []).constant('Constants', {
-  // if the management REST API is on a different domain, put something like: http://[api-rest-domain]/management/
-  "baseURL": '/management/',
-  "version": "0.8.2"
-});
+{
+	"baseURL": "http://localhost:8083/management/",
+	"portalTitle": "Gravitee.io Portal",
+	...
+}
+
+Please note that baseURL has to point to the running instance of Management API and follow format of `http://[api-management-domain:port]/management/`
+
 
 == Configuration
 


### PR DESCRIPTION
This was already mentioned in the preview version of the document. However I still missed that point. I hope that this slight modification will make it even more obvious that baseURL has to point to Management API instamce. Plus there is no "angular.module(" in actual file.