### PR TITLE
Add base_url in json sample

### DIFF
--- a/pages/apim/installation-guide/installation-guide-portal-configuration.adoc
+++ b/pages/apim/installation-guide/installation-guide-portal-configuration.adoc
@@ -41,6 +41,7 @@ __You have to provide a full json in case of update. Otherwise, this will store 
 [source,json]
 ----
 {
+  "baseURL": "gravitee_management_api_url",
   "company" : {
     "name" : "Gravitee.io"
   },


### PR DESCRIPTION
I've done a copy of the default json to make the upgrade.
Even if you highlighted that base_url is mandatory, it's easier to have it in the json sample...