### PR TITLE
docs: add path property

### DIFF
--- a/pages/apim/user-guide/publisher/expression-language.adoc
+++ b/pages/apim/user-guide/publisher/expression-language.adoc
@@ -62,6 +62,11 @@ be retrieved using EL by using the following syntax:
 ^.^|key / value
 ^.^|X
 
+.^|path
+|Request path
+^.^| string
+^.^|X
+
 .^|paths
 |Request path parts
 ^.^|array of string


### PR DESCRIPTION
In the expression language properties, path was missing (give a string with the full path).