### PR TITLE
fix: Hazelcast config is not correct in gravitee.yml

### DIFF
--- a/pages/ae/installation-guide/installation-guide-configuration.adoc
+++ b/pages/ae/installation-guide/installation-guide-configuration.adoc
@@ -40,12 +40,9 @@ services:
     prometheus:
       enabled: true
 
-alerts:
-  plugin:
-    enabled: true
-    hazelcast:
-      config:
-        path: ${gravitee.home}/config/hazelcast.xml
+hazelcast:
+  config:
+    path: ${gravitee.home}/config/hazelcast.xml
 
 notifiers:
   email:


### PR DESCRIPTION
This closes https://github.com/gravitee-io/gravitee-alert-engine/issues/18