### PR TITLE
add subject template value to smtp configuration

### DIFF
--- a/pages/apim/installation-guide/installation-guide-management-api-configuration.adoc
+++ b/pages/apim/installation-guide/installation-guide-management-api-configuration.adoc
@@ -165,6 +165,7 @@ email:
   host: smtp.my.domain
   port: 465
   from: noreply@my.domain
+  subject: "[Gravitee.io] %s"
   username: user@my.domain
   password: password
 ----
@@ -180,6 +181,7 @@ email:
   host: smtp.gmail.com
   port: 587
   from: user@gmail.com
+  subject: "[Gravitee.io] %s"
   username: user@gmail.com
   password: xxxxxxxx
   properties:


### PR DESCRIPTION
The subject template value is missing from the documentation about smtp configuration.