### PR TITLE
apim: Updated MongoDB Client security gw missing RW on  'commands' collection.

### DIFF
--- a/pages/apim/installation-guide/installation-guide-repositories-mongodb.adoc
+++ b/pages/apim/installation-guide/installation-guide-repositories-mongodb.adoc
@@ -82,7 +82,7 @@ Thanks to the following table, you will be able to define these fine-grained con
 |Component|Read-only |Read-write
 
 |API Gateway
-|apis - keys - subscriptions - plans | events - ratelimit
+|apis - keys - subscriptions - plans | events - ratelimit - commands
 
 |Management API
 |- | all collections except ratelimit


### PR DESCRIPTION
 Gateway can't start without readWrite (createIndex) on 'commands' collection.

I don't know if there is other collections right missing.

