### PR TITLE
Wrong response in AM Gateway test

### DIFF
--- a/pages/am/3.x/installation-guide/installation-guide-gateway-install-zip.adoc
+++ b/pages/am/3.x/installation-guide/installation-guide-gateway-install-zip.adoc
@@ -71,7 +71,7 @@ You can test that your AM Gateway node is running by sending an HTTP request to 
 $ curl -X GET http://localhost:8092/
 ----
 
-which should give you an empty 404 response (no context-path found)
+which should give you an empty 404 response (No security domain matches the request URI.)
 
 == Running as a daemon
 


### PR DESCRIPTION
When you test if AM gateway is running the response is:
```
 curl -X GET http://localhost:8092
No security domain matches the request
```