### PR TITLE
Update docs with ES folder permissions

### DIFF
--- a/pages/apim/3.x/installation-guide/docker/installation-guide-docker_compose.adoc
+++ b/pages/apim/3.x/installation-guide/docker/installation-guide-docker_compose.adoc
@@ -20,7 +20,14 @@ You can launch a complete Gravitee.io API Management stack using our ready-to-us
 
 This latest is including Gravitee.io API Management + MongoDB + Elasticsearch.
 
-WARNING: Before running the commands below, make sure you have the minimum vm.max_map_count property set in order to run Elasticsearch properly. https://www.elastic.co/guide/en/elasticsearch/reference/current/vm-max-map-count.html[Click here] to see how to check the current value and update if necessary.
+[WARNING] 
+.Elasticsearch configuration
+====
+Before running the commands below:
+
+. Make sure you have the minimum vm.max_map_count property set in order to run Elasticsearch properly. https://www.elastic.co/guide/en/elasticsearch/reference/current/vm-max-map-count.html[Click here] to see how to check the current value and update if necessary.
+. Make sure the folder (e.g. `elasticsearch`) defined as the ES volume, within the docker-compose file, is https://www.elastic.co/guide/en/elasticsearch/reference/current/docker.html#_configuration_files_must_be_readable_by_the_elasticsearch_user[readable by elasticsearch user]: `sudo chmod g+rwx elasticsearch/ && sudo chgrp 0 elasticsearch/`
+====
 
 [source,shell]
 ....


### PR DESCRIPTION
ES requires special folder permissions when bind-mounting a local directory as explained [here](https://www.elastic.co/guide/en/elasticsearch/reference/current/docker.html#_configuration_files_must_be_readable_by_the_elasticsearch_user)