### PR TITLE
docs: improve documentation for quickstart

### DIFF
--- a/_data/sidebars/apim_3_x_sidebar.yml
+++ b/_data/sidebars/apim_3_x_sidebar.yml
@@ -31,12 +31,32 @@ entries:
       - title: QuickStart
         output: web
         folderitems:
-          - title: Publish your first API
+          - title: Overview
             output: web
-            url: /apim/3.x/apim_quickstart_publish.html
-          - title: Consume an API
-            output: web
-            url: /apim/3.x/apim_quickstart_consume.html
+            url: /apim/3.x/apim_quickstart_overview.html
+
+            subfolders:
+              - title: Publish your first API
+                output: web
+                subfolderitems:
+                  - title: Using Management UI
+                    output: web
+                    url: /apim/3.x/apim_quickstart_publish_ui.html
+                  - title: Using Management API
+                    output: web
+                    url: /apim/3.x/apim_quickstart_publish_api.html
+              - title: Consume an API
+                output: web
+                subfolderitems:
+                  - title: Using Portal UI
+                    output: web
+                    url: /apim/3.x/apim_quickstart_consume_ui.html
+                  - title: Using Management API
+                    output: web
+                    url: /apim/3.x/apim_quickstart_consume_api.html
+                  - title: Test your API
+                    output: web
+                    url: /apim/3.x/apim_quickstart_consume_test.html
 
       - title: Installation Guide
         output: web

--- a/pages/apim/3.x/dev-guide/dev-guide-policies.adoc
+++ b/pages/apim/3.x/dev-guide/dev-guide-policies.adoc
@@ -11,7 +11,7 @@ Let's go deeper by take an example of how develop a _policy_.
 
 == Getting started
 
-Before to go, don't forget to activate the http://central.sonatype.org/pages/ossrh-guide.html[OSS repositories] in your https://maven.apache.org/settings.html[Maven settings].
+Before to go, don't forget to activate the http://central.sonatype.org/pages/ossrh-guide.html[OSS repositories, window=\"_blank\"] in your https://maven.apache.org/settings.html[Maven settings, window=\"_blank\"].
 
 == Policy skeleton generation
 

--- a/pages/apim/3.x/installation-guide/amazon-linux/installation-guide-amazon-stack.adoc
+++ b/pages/apim/3.x/installation-guide/amazon-linux/installation-guide-amazon-stack.adoc
@@ -51,7 +51,7 @@ Before this, you may potentially have to add third-party repositories:
 
 ==== MongoDB
 
-NOTE: Please have a look to the link:https://docs.mongodb.com/v3.6/tutorial/install-mongodb-on-amazon/[MongoDB Installation documentation]
+NOTE: Please have a look to the link:https://docs.mongodb.com/v3.6/tutorial/install-mongodb-on-amazon/[MongoDB Installation documentation, window=\"_blank\"]
 
 [source,bash]
 ----

--- a/pages/apim/3.x/installation-guide/docker/installation-guide-docker_compose.adoc
+++ b/pages/apim/3.x/installation-guide/docker/installation-guide-docker_compose.adoc
@@ -9,10 +9,10 @@
 :docker-hub: https://hub.docker.com/r/graviteeio
 
 IMPORTANT: We assume that you are familiar with Docker. +
-To run our official images, you must start by installing https://docs.docker.com/installation/[Docker]
+To run our official images, you must start by installing https://docs.docker.com/installation/[Docker, window=\"_blank\"]
 
-Gravitee.io docker images are https://hub.docker.com/u/graviteeio/[available on Docker Hub].
-You could find all https://github.com/gravitee-io/gravitee-docker/[Dockerfiles on GitHub].
+Gravitee.io docker images are https://hub.docker.com/u/graviteeio/[available on Docker Hub, window=\"_blank\"].
+You could find all https://github.com/gravitee-io/gravitee-docker/[Dockerfiles on GitHub, window=\"_blank\"].
 
 == Run Gravitee.io API Management
 
@@ -25,8 +25,8 @@ This latest is including Gravitee.io API Management + MongoDB + Elasticsearch.
 ====
 Before running the commands below:
 
-. Make sure you have the minimum vm.max_map_count property set in order to run Elasticsearch properly. https://www.elastic.co/guide/en/elasticsearch/reference/current/vm-max-map-count.html[Click here] to see how to check the current value and update if necessary.
-. Make sure the folder (e.g. `elasticsearch`) defined as the ES volume, within the docker-compose file, is https://www.elastic.co/guide/en/elasticsearch/reference/current/docker.html#_configuration_files_must_be_readable_by_the_elasticsearch_user[readable by elasticsearch user]: `sudo chmod g+rwx elasticsearch/ && sudo chgrp 0 elasticsearch/`
+. Make sure you have the minimum vm.max_map_count property set in order to run Elasticsearch properly. https://www.elastic.co/guide/en/elasticsearch/reference/current/vm-max-map-count.html[Click here, window=\"_blank\"] to see how to check the current value and update if necessary.
+. Make sure the folder (e.g. `elasticsearch`) defined as the ES volume, within the docker-compose file, is https://www.elastic.co/guide/en/elasticsearch/reference/current/docker.html#_configuration_files_must_be_readable_by_the_elasticsearch_user[readable by elasticsearch user, window=\"_blank\"]: `sudo chmod g+rwx elasticsearch/ && sudo chgrp 0 elasticsearch/`
 ====
 
 [source,shell]

--- a/pages/apim/3.x/installation-guide/docker/installation-guide-docker_customize.adoc
+++ b/pages/apim/3.x/installation-guide/docker/installation-guide-docker_customize.adoc
@@ -9,13 +9,13 @@
 :docker-hub: https://hub.docker.com/r/graviteeio
 
 IMPORTANT: We assume that you are familiar with Docker. +
-To run our official images, you must start by installing https://docs.docker.com/installation/[Docker]
+To run our official images, you must start by installing https://docs.docker.com/installation/[Docker, window=\"_blank\"]
 
-Gravitee.io docker images are https://hub.docker.com/u/graviteeio/[available on Docker Hub].
+Gravitee.io docker images are https://hub.docker.com/u/graviteeio/[available on Docker Hub, window=\"_blank\"].
 
 == Install an additional plugin
 
-Gravitee.io images are containing the default plugins (you can get the full list from https://github.com/gravitee-io/release/blob/3.0.x/release.json).
+Gravitee.io images are containing the default plugins (you can get the full list from https://github.com/gravitee-io/release/blob/3.0.x/release.json[window=\"_blank\"]).
 
 Sometimes, you may need to override the default setup by providing a custom plugin.
 

--- a/pages/apim/3.x/installation-guide/docker/installation-guide-docker_images.adoc
+++ b/pages/apim/3.x/installation-guide/docker/installation-guide-docker_images.adoc
@@ -8,9 +8,9 @@
 :docker-hub: https://hub.docker.com/r/graviteeio
 
 IMPORTANT: We assume that you are familiar with Docker. +
-To run our official images, you must start by installing https://docs.docker.com/installation/[Docker]
+To run our official images, you must start by installing https://docs.docker.com/installation/[Docker, window=\"_blank\"]
 
-Gravitee.io docker images are https://hub.docker.com/u/graviteeio/[available on Docker Hub].
+Gravitee.io docker images are https://hub.docker.com/u/graviteeio/[available on Docker Hub, window=\"_blank\"].
 
 We provide a complete set of images.
 
@@ -20,19 +20,19 @@ We provide a complete set of images.
 
 |{docker-hub}/apim-gateway/[graviteeio/apim-gateway]
 |latest
-|https://hub.docker.com/r/adoptopenjdk/openjdk11[openjdk11:jre-11.0.7_10-alpine]
+|https://hub.docker.com/r/adoptopenjdk/openjdk11[openjdk11:jre-11.0.7_10-alpine, window=\"_blank\"]
 
 |{docker-hub}/apim-management-api/[graviteeio/apim-management-api]
 |latest
-|https://hub.docker.com/r/adoptopenjdk/openjdk11[openjdk11:jre-11.0.7_10-alpine]
+|https://hub.docker.com/r/adoptopenjdk/openjdk11[openjdk11:jre-11.0.7_10-alpine, window=\"_blank\"]
 
 |{docker-hub}/apim-management-ui/[graviteeio/apim-management-ui]
 |latest
-|https://hub.docker.com/_/nginx/[nginx:1.18-alpine]
+|https://hub.docker.com/_/nginx/[nginx:1.18-alpine, window=\"_blank\"]
 
 |{docker-hub}/apim-portal-ui/[graviteeio/apim-portal-ui]
 |latest
-|https://hub.docker.com/_/nginx/[nginx:1.18-alpine]
+|https://hub.docker.com/_/nginx/[nginx:1.18-alpine, window=\"_blank\"]
 
 |===
 

--- a/pages/apim/3.x/installation-guide/gateway/installation-guide-gateway-configuration.adoc
+++ b/pages/apim/3.x/installation-guide/gateway/installation-guide-gateway-configuration.adoc
@@ -131,7 +131,7 @@ plugins:
 Management repository is used to store global configuration such as APIs, applications, apikeys, ...
 This is the default configuration using MongoDB (single server). For more information about MongoDB configuration, please have a look to:
 
-http://api.mongodb.org/java/current/com/mongodb/MongoClientOptions.html
+http://api.mongodb.org/java/current/com/mongodb/MongoClientOptions.html[window=\"_blank\"]
 
 [source,yaml]
 ----

--- a/pages/apim/3.x/installation-guide/red-hat/installation-guide-redhat-stack.adoc
+++ b/pages/apim/3.x/installation-guide/red-hat/installation-guide-redhat-stack.adoc
@@ -51,7 +51,7 @@ Before this, you may potentially have to add third-party repositories:
 
 ==== MongoDB
 
-NOTE: Please have a look to the link:https://docs.mongodb.com/v3.6/tutorial/install-mongodb-on-red-hat/[MongoDB Installation documentation]
+NOTE: Please have a look to the link:https://docs.mongodb.com/v3.6/tutorial/install-mongodb-on-red-hat/[MongoDB Installation documentation, window=\"_blank\"]
 
 [source,bash]
 ----
@@ -68,7 +68,7 @@ sudo systemctl start mongod
 
 ==== Elasticsearch 7.x
 
-NOTE: Please have a look to the link:https://www.elastic.co/guide/en/elasticsearch/reference/7.6/rpm.html#rpm-repo[Elasticsearch Installation documentation].
+NOTE: Please have a look to the link:https://www.elastic.co/guide/en/elasticsearch/reference/7.6/rpm.html#rpm-repo[Elasticsearch Installation documentation, window=\"_blank\"].
 
 [source,bash]
 ----

--- a/pages/apim/3.x/installation-guide/repositories/installation-guide-repositories-elasticsearch.adoc
+++ b/pages/apim/3.x/installation-guide/repositories/installation-guide-repositories-elasticsearch.adoc
@@ -17,7 +17,7 @@ WARNING: Gravitee.io no longer supports native ES client and previous connector 
 
 === Management API configuration
 
-WARNING: The ElasticSearch client does not support URL schemes in the form of `http://$USERNAME:$PASSWORD@server.org`. You MUST provide the username and password via the `analytics.elasticsearch.security.username` and `analytics.elasticsearch.security.password` properties.
+WARNING: The ElasticSearch client does not support URL schemes in the form of `http://USERNAME:PASSWORD@server.org`. You MUST provide the username and password via the `analytics.elasticsearch.security.username` and `analytics.elasticsearch.security.password` properties.
 
 [source,yaml]
 ----

--- a/pages/apim/3.x/installation-guide/repositories/installation-guide-repositories-mongodb.adoc
+++ b/pages/apim/3.x/installation-guide/repositories/installation-guide-repositories-mongodb.adoc
@@ -12,11 +12,11 @@
 |Version tested | Gravitee.io Plugin
 
 |3.6 / 4.0 / 4.2
-|https://download.gravitee.io/graviteeio-apim/plugins/repositories/gravitee-repository-mongodb/[Download the same version as your APIM platform]
+|https://download.gravitee.io/graviteeio-apim/plugins/repositories/gravitee-repository-mongodb/[Download the same version as your APIM platform, window=\"_blank\"]
 |===
 
 == Configuration
-https://www.mongodb.org/[MongoDB] is the default repository implementation used by Gravitee.io API Management.
+https://www.mongodb.org/[MongoDB, window=\"_blank\"] is the default repository implementation used by Gravitee.io API Management.
 
 Let's see the configuration options:
 
@@ -78,7 +78,7 @@ NOTE: All theses properties allow you to fine tuned your MongoDB connection
 
 == Index
 
-A https://github.com/gravitee-io/gravitee-repository-mongodb/blob/master/src/main/resources/scripts/create-index.js[script] is available from our MongoDB GitHub Repository.
+A https://github.com/gravitee-io/gravitee-repository-mongodb/blob/master/src/main/resources/scripts/create-index.js[script, window=\"_blank\"] is available from our MongoDB GitHub Repository.
 Please use the correct version of this script depending on the version of Gravitee.io API Management you are running.
 
 

--- a/pages/apim/3.x/installation-guide/repositories/installation-guide-repositories.adoc
+++ b/pages/apim/3.x/installation-guide/repositories/installation-guide-repositories.adoc
@@ -18,10 +18,10 @@ Here is the matrix between scopes and implementations.
 |===
 
 |Scope
-|link:/apim/3.x/apim_installguide_repositories_mongodb.html[MongoDB]
-|link:/apim/3.x/apim_installguide_repositories_redis.html[Redis]
-|link:/apim/3.x/apim_installguide_repositories_elasticsearch.html[Elasticsearch]
-|link:/apim/3.x/apim_installguide_repositories_jdbc.html[JDBC]
+|MongoDB
+|Redis
+|Elasticsearch
+|JDBC
 
 |Management
 |X
@@ -48,3 +48,9 @@ applications, plans, ...
 Rate Limit:: Rate limiting data
 Analytics:: Analytics data
 
+== More informations:
+
+* link:/apim/3.x/apim_installguide_repositories_mongodb.html[MongoDB]
+* link:/apim/3.x/apim_installguide_repositories_redis.html[Redis]
+* link:/apim/3.x/apim_installguide_repositories_elasticsearch.html[Elasticsearch]
+* link:/apim/3.x/apim_installguide_repositories_jdbc.html[JDBC]

--- a/pages/apim/3.x/installation-guide/with-zip/installation-guide-gateway-install-zip.adoc
+++ b/pages/apim/3.x/installation-guide/with-zip/installation-guide-gateway-install-zip.adoc
@@ -19,19 +19,19 @@ $ java -version
 $ echo $JAVA_HOME
 ----
 
-NOTE: You can download the latest OpenJDK from https://jdk.java.net/archive/[OpenJDK Download Site].
+NOTE: You can download the latest OpenJDK from https://jdk.java.net/archive/[OpenJDK Download Site, window=\"_blank\"].
 
 === Repository
 
-Default API Gateway distribution requires link:/apim/3.x/apim_installguide_repositories_mongodb.html[MongoDB] to poll environment configuration and link:/apim/3.x/apim_installguide_repositories_elasticsearch.html[Elasticsearch] for
+Default API Gateway distribution requires link:/apim/3.x/apim_installguide_repositories_mongodb.html[MongoDB, window=\"_blank\"] to poll environment configuration and link:/apim/3.x/apim_installguide_repositories_elasticsearch.html[Elasticsearch, window=\"_blank\"] for
 reporting / analytics. Please refer to the respective documentation page for supported versions.
 
-NOTE: You can download MongoDB from https://www.mongodb.org/downloads#production[MongoDB Download Site]
-and Elasticsearch from https://www.elastic.co/downloads/elasticsearch[Elastic Download Site]
+NOTE: You can download MongoDB from https://www.mongodb.org/downloads#production[MongoDB Download Site, window=\"_blank\"]
+and Elasticsearch from https://www.elastic.co/downloads/elasticsearch[Elastic Download Site, window=\"_blank\"]
 
 == Download and install the +.zip+ package
 
-Binaries are available from https://gravitee.io/downloads/api-management[Downloads page] or via https://download.gravitee.io/graviteeio-apim/distributions/graviteeio-full-{{ site.products.apim._3x.version }}.zip[Download].
+Binaries are available from https://gravitee.io/downloads/api-management[Downloads page, window=\"_blank\"] or via https://download.gravitee.io/graviteeio-apim/distributions/graviteeio-full-{{ site.products.apim._3x.version }}.zip[Download, window=\"_blank\"].
 
 [source,bash]
 ----

--- a/pages/apim/3.x/installation-guide/with-zip/installation-guide-management-ui-install-zip.adoc
+++ b/pages/apim/3.x/installation-guide/with-zip/installation-guide-management-ui-install-zip.adoc
@@ -15,7 +15,7 @@ Management UI has been tested with the latest versions of Google Chrome, Firefox
 
 == Installing from the ZIP archive
 
-The binaries are available from https://gravitee.io/downloads/api-management[Downloads page] or via https://download.gravitee.io/graviteeio-apim/distributions/graviteeio-full-{{ site.products.apim._3x.version }}.zip[Download].
+The binaries are available from https://gravitee.io/downloads/api-management[Downloads page, window=\"_blank\"] or via https://download.gravitee.io/graviteeio-apim/distributions/graviteeio-full-{{ site.products.apim._3x.version }}.zip[Download, window=\"_blank\"].
 
 [source,bash]
 [subs="attributes"]
@@ -29,7 +29,7 @@ $ unzip gravitee-standalone-distribution-{{ site.products.apim._3x.version }}.zi
 
 === Deploy
 
-The Management UI is a client-side only AngularJS application and can be deployed on any HTTP server like https://httpd.apache.org/[Apache] or http://nginx.org/[Nginx].
+The Management UI is a client-side only AngularJS application and can be deployed on any HTTP server like https://httpd.apache.org/[Apache, window=\"_blank\"] or http://nginx.org/[Nginx, window=\"_blank\"].
 
 === or Run it
 

--- a/pages/apim/3.x/quickstart/api-consumer/api-consumer-api.adoc
+++ b/pages/apim/3.x/quickstart/api-consumer/api-consumer-api.adoc
@@ -1,0 +1,40 @@
+= Consuming an API with Management API
+:page-sidebar: apim_3_x_sidebar
+:page-permalink: apim/3.x/apim_quickstart_consume_api.html
+:page-folder: apim/quickstart
+:page-layout: apim3x
+
+NOTE: See the link:/apim/3.x/apim_quickstart_publish_api.html[API publisher QuickStart guide] to set up your first API
+
+This guide walks you through the process of creating your first application and subscribing your first API by using the Portal UI.
+Gravitee.io Portal UI can be accessed using the following URL:
+
+http://MANAGEMENT_API_SERVER_DOMAIN (see link:/apim/3.x/apim_installguide_rest_apis_install_zip.html[Gravitee.io Management API installation] for more information)
+
+
+NOTE: Gravitee.io offers differents ways to access/secure an API (link:/apim/3.x/apim_publisherguide_plans_subscriptions.html[Gravitee.io Plans]).
+In this quick start, we will access an API via an link:/apim/3.x/apim_policies_apikey.html[API Key].
+Only trusted application can access the API data by requesting an API Key.
+Let's see how to create an application and generate an API Key.
+
+== Create your application with Portal API
+
+Create Application request::
+[source]
+----
+curl -H "Authorization: Basic YWRtaW46YWRtaW4=" \
+     -H "Content-Type:application/json;charset=UTF-8" \
+     -X POST \
+     -d '{"name":"My first Application","type":"Web","description":"Web client for Gravitee.io Echo API"}' \
+     http://MANAGEMENT_API_SERVER_DOMAIN/portal/environments/DEFAULT/applications
+----
+
+Subscribe API request::
+[source]
+----
+curl -H "Authorization: Basic YWRtaW46YWRtaW4=" \
+     -X POST \
+     http://MANAGEMENT_API_SERVER_DOMAIN/portal/environments/DEFAULT/applications/|application-id|/subscriptions/?plan=|plan-id|
+----
+
+For more information, you can find the full link:/apim/3.x/apim_installguide_rest_apis_documentation.html[Rest APIs Documentation].

--- a/pages/apim/3.x/quickstart/api-consumer/api-consumer-test.adoc
+++ b/pages/apim/3.x/quickstart/api-consumer/api-consumer-test.adoc
@@ -1,0 +1,32 @@
+= Test your API
+:page-sidebar: apim_3_x_sidebar
+:page-permalink: apim/3.x/apim_quickstart_consume_test.html
+:page-folder: apim/quickstart
+:page-layout: apim3x
+
+Now that you have created your application, you need to get your API Key
+
+. Click `Applications` in the top menu
+. Click `My subscriptions` in the sub-menu
+. Select your application in the left list
+. Select the API in the right list
+. Copy thr curl command
+
+image::apim/3.x/quickstart/consume/graviteeio-create-first-app-9.png[]
+
+[IMPORTANT]
+====
+By default, the host in the command is `https://api.company.com`. It has to be configured in the Management UI Settings.
+
+image::apim/3.x/quickstart/consume/graviteeio-settings-sharding-tags.png[]
+====
+
+NOTE: You can use your API Key by setting the HTTP Header `X-Gravitee-Api-Key` or using the request query parameter `api-key`.
+
+[source]
+----
+curl http://GATEWAY_SERVER_DOMAIN/myfirstapi \
+     -H "X-Gravitee-Api-Key:<your-api-key>"
+----
+
+You can see that the Gravitee.io Echo API data has been served successfully. You can test different requests specified in the https://github.com/gravitee-io/gravitee-sample-apis/blob/master/gravitee-echo-api/README.md[Gravitee.io Echo API documentation].

--- a/pages/apim/3.x/quickstart/api-consumer/api-consumer-ui.adoc
+++ b/pages/apim/3.x/quickstart/api-consumer/api-consumer-ui.adoc
@@ -1,10 +1,10 @@
-= Consuming an API
+= Consuming an API with Portal UI
 :page-sidebar: apim_3_x_sidebar
-:page-permalink: apim/3.x/apim_quickstart_consume.html
+:page-permalink: apim/3.x/apim_quickstart_consume_ui.html
 :page-folder: apim/quickstart
 :page-layout: apim3x
 
-NOTE: See the link:/apim/3.x/apim_quickstart_publish.html[API publisher QuickStart guide] to set up your first API
+NOTE: See the link:/apim/3.x/apim_quickstart_publish_ui.html[API publisher QuickStart guide] to set up your first API
 
 This guide walks you through the process of creating your first application and subscribing your first API by using the Portal UI.
 Gravitee.io Portal UI can be accessed using the following URL:
@@ -17,8 +17,7 @@ In this quick start, we will access an API via an link:/apim/3.x/apim_policies_a
 Only trusted application can access the API data by requesting an API Key.
 Let's see how to create an application and generate an API Key.
 
-== Create your application...
-=== ...with Portal UI
+== Create your application with Portal UI
 
 . Login to http://PORTAL_UI_SERVER_DOMAIN. (Default Administrator account is admin/admin, see link:/apim/3.x/apim_installguide_authentication.html[security section] for more information)
 . Click `Applications` in the top menu
@@ -64,54 +63,3 @@ image::apim/3.x/quickstart/consume/graviteeio-create-first-app-7.png[]
 . Congratulations ! Your brand-new Application and a subscription to the Echo API have been created.
 
 image::apim/3.x/quickstart/consume/graviteeio-create-first-app-8.png[]
-
-
-
-=== ...with Portal API
-
-Create Application request::
-[source]
-----
-curl -H "Authorization: Basic YWRtaW46YWRtaW4=" \
-     -H "Content-Type:application/json;charset=UTF-8" \
-     -X POST \
-     -d '{"name":"My first Application","type":"Web","description":"Web client for Gravitee.io Echo API"}' \
-     http://MANAGEMENT_API_SERVER_DOMAIN/portal/environments/DEFAULT/applications
-----
-
-Subscribe API request::
-[source]
-----
-curl -H "Authorization: Basic YWRtaW46YWRtaW4=" \
-     -X POST \
-     http://MANAGEMENT_API_SERVER_DOMAIN/portal/environments/DEFAULT/applications/|application-id|/subscriptions/?plan=|plan-id|
-----
-
-== Test your API !
-
-Now that you have created your application, you need to get your API Key
-
-. Click `Applications` in the top menu
-. Click `My subscriptions` in the sub-menu
-. Select your application in the left list
-. Select the API in the right list
-. Copy thr curl command
-
-image::apim/3.x/quickstart/consume/graviteeio-create-first-app-9.png[]
-
-[IMPORTANT]
-====
-By default, the host in the command is `https://api.company.com`. It has to be configured in the Management UI Settings.
-
-image::apim/3.x/quickstart/consume/graviteeio-settings-sharding-tags.png[]
-====
-
-NOTE: You can use your API Key by setting the HTTP Header `X-Gravitee-Api-Key` or using the request query parameter `api-key`.
-
-[source]
-----
-curl http://GATEWAY_SERVER_DOMAIN/myfirstapi \
-     -H "X-Gravitee-Api-Key:<your-api-key>"
-----
-
-You can see that the Gravitee.io Echo API data has been served successfully. You can test different requests specified in the https://github.com/gravitee-io/gravitee-sample-apis/blob/master/gravitee-echo-api/README.md[Gravitee.io Echo API documentation].

--- a/pages/apim/3.x/quickstart/api-publisher/api-publisher-api.adoc
+++ b/pages/apim/3.x/quickstart/api-publisher/api-publisher-api.adoc
@@ -1,0 +1,73 @@
+= Publish your first API with Management API
+:page-sidebar: apim_3_x_sidebar
+:page-permalink: apim/3.x/apim_quickstart_publish_api.html
+:page-folder: apim/quickstart/api-publisher
+:page-layout: apim3x
+
+This guide walks you through the process of creating and publishing your first API by using the Management API.
+Gravitee.io Management API can be accessed using the following URL:
+
+http://MANAGEMENT_API_SERVER_DOMAIN (see link:/apim/3.x/apim_installguide_rest_apis_install_zip.html[Gravitee.io Management API installation] for more information)
+
+
+NOTE: *Gravitee.io Echo API* : In this tutorial we will use the https://api.gravitee.io/echo[Gravitee.io Echo API] to set up our first proxy API.
+The Gravitee.io Echo API returns JSON-formatted data via the following URL : https://api.gravitee.io/echo
+
+== Create your API with the Management API
+Create API request::
+[source]
+----
+curl -H "Authorization: Basic YWRtaW46YWRtaW4=" \
+     -H "Content-Type:application/json;charset=UTF-8" \
+     -X POST \
+     -d '{"name":"My first API","version":"1","description":"Gravitee.io Echo API Proxy","contextPath":"/myfirstapi","endpoint":"https://api.gravitee.io/echo"}' \
+     http://MANAGEMENT_API_SERVER_DOMAIN/management/organizations/DEFAULT/environments/DEFAULT/apis
+----
+
+Create Plan request::
+[source]
+----
+curl -H "Authorization: Basic YWRtaW46YWRtaW4=" \
+     -H "Content-Type:application/json;charset=UTF-8" \
+     -X POST \
+     -d '{"name":"My Plan","description":"Unlimited access plan","validation":"auto","characteristics":[],"paths":{"/":[]},"security":"api_key"}' \
+     http://MANAGEMENT_API_SERVER_DOMAIN/management/organizations/DEFAULT/environments/DEFAULT/apis/|api-id|/plans
+----
+
+Publish Plan request::
+[source]
+----
+curl -H "Authorization: Basic YWRtaW46YWRtaW4=" \
+     -H "Content-Type:application/json;charset=UTF-8" \
+     -X POST \
+     http://MANAGEMENT_API_SERVER_DOMAIN/management/apis/|api-id|/plans/|plan-id|/_publish
+----
+
+Deploy API request::
+[source]
+----
+curl -H "Authorization: Basic YWRtaW46YWRtaW4=" \
+     -X POST \
+     http://MANAGEMENT_API_SERVER_DOMAIN/management/apis/|api-id|/deploy
+----
+
+Start API request::
+[source]
+----
+curl -H "Authorization: Basic YWRtaW46YWRtaW4=" \
+     -X POST \
+     http://MANAGEMENT_API_SERVER_DOMAIN/management/apis/|api-id|?action=START
+----
+
+Publish API on Portal request::
+From the JSON response of `the Create API Request`, add the field `lifecyle_state` with value ="published" and send the result in a PUT request.
+[source]
+----
+curl -H "Authorization: Basic YWRtaW46YWRtaW4=" \
+     -H "Content-Type:application/json;charset=UTF-8" \
+     -X PUT \
+     -d '<RESPONSE_FROM_CREATE_API_REQUEST + ",lifecyle_state":"published">'
+'     http://MANAGEMENT_API_SERVER_DOMAIN/management/apis/|api-id|
+----
+
+For more information, you can find the full link:/apim/3.x/apim_installguide_rest_apis_documentation.html[Rest APIs Documentation].

--- a/pages/apim/3.x/quickstart/api-publisher/api-publisher-ui.adoc
+++ b/pages/apim/3.x/quickstart/api-publisher/api-publisher-ui.adoc
@@ -1,7 +1,7 @@
-= Publish your first API
+= Publish your first API with Management UI
 :page-sidebar: apim_3_x_sidebar
-:page-permalink: apim/3.x/apim_quickstart_publish.html
-:page-folder: apim/quickstart
+:page-permalink: apim/3.x/apim_quickstart_publish_ui.html
+:page-folder: apim/quickstart/api-publisher
 :page-layout: apim3x
 
 This guide walks you through the process of creating and publishing your first API by using the Management UI.
@@ -66,60 +66,3 @@ image::apim/3.x/quickstart/publish/graviteeio-create-first-api-7.png[]
 Now let's see how to consume your API: link:/apim/3.x/apim_quickstart_consume.html[Use your first API]
 
 NOTE: This quick start was just an overview to create your first API. To go further into API management detail, you can take a look at the link:/apim/3.x/apim_publisherguide_manage_apis.html[User Guide]
-
-== Create your API with the Management API
-Create API request::
-[source]
-----
-curl -H "Authorization: Basic YWRtaW46YWRtaW4=" \
-     -H "Content-Type:application/json;charset=UTF-8" \
-     -X POST \
-     -d '{"name":"My first API","version":"1","description":"Gravitee.io Echo API Proxy","contextPath":"/myfirstapi","endpoint":"https://api.gravitee.io/echo"}' \
-     http://MANAGEMENT_API_SERVER_DOMAIN/management/organizations/DEFAULT/environments/DEFAULT/apis
-----
-
-Create Plan request::
-[source]
-----
-curl -H "Authorization: Basic YWRtaW46YWRtaW4=" \
-     -H "Content-Type:application/json;charset=UTF-8" \
-     -X POST \
-     -d '{"name":"My Plan","description":"Unlimited access plan","validation":"auto","characteristics":[],"paths":{"/":[]},"security":"api_key"}' \
-     http://MANAGEMENT_API_SERVER_DOMAIN/management/organizations/DEFAULT/environments/DEFAULT/apis/|api-id|/plans
-----
-
-Publish Plan request::
-[source]
-----
-curl -H "Authorization: Basic YWRtaW46YWRtaW4=" \
-     -H "Content-Type:application/json;charset=UTF-8" \
-     -X POST \
-     http://MANAGEMENT_API_SERVER_DOMAIN/management/apis/|api-id|/plans/|plan-id|/_publish
-----
-
-Deploy API request::
-[source]
-----
-curl -H "Authorization: Basic YWRtaW46YWRtaW4=" \
-     -X POST \
-     http://MANAGEMENT_API_SERVER_DOMAIN/management/apis/|api-id|/deploy
-----
-
-Start API request::
-[source]
-----
-curl -H "Authorization: Basic YWRtaW46YWRtaW4=" \
-     -X POST \
-     http://MANAGEMENT_API_SERVER_DOMAIN/management/apis/|api-id|?action=START
-----
-
-Publish API on Portal request::
-From the JSON response of `the Create API Request`, add the field `lifecyle_state` with value ="published" and send the result in a PUT request.
-[source]
-----
-curl -H "Authorization: Basic YWRtaW46YWRtaW4=" \
-     -H "Content-Type:application/json;charset=UTF-8" \
-     -X PUT \
-     -d '<RESPONSE_FROM_CREATE_API_REQUEST + ",lifecyle_state":"published">'
-'     http://MANAGEMENT_API_SERVER_DOMAIN/management/apis/|api-id|
-----

--- a/pages/apim/3.x/quickstart/quickstart-overview.adoc
+++ b/pages/apim/3.x/quickstart/quickstart-overview.adoc
@@ -1,0 +1,7 @@
+= Overview
+:page-sidebar: apim_3_x_sidebar
+:page-permalink: apim/3.x/apim_quickstart_overview.html
+:page-folder: apim/quickstart
+:page-layout: apim3x
+
+This user guide helps you to publish and consume your first API on Gravitee.io using Management UI or Management API.

--- a/pages/apim/3.x/user-guide/publisher/documentation/publish-documentation.adoc
+++ b/pages/apim/3.x/user-guide/publisher/documentation/publish-documentation.adoc
@@ -90,7 +90,7 @@ image::apim/3.x/api-publisher-guide/documentation/graviteeio-page-documentation-
 
 === Templating
 
-We will see how to create templates of documentation based on https://freemarker.apache.org[freemarker template engine].
+We will see how to create templates of documentation based on https://freemarker.apache.org[freemarker template engine, window=\"_blank\"].
 
 ==== Syntax
 


### PR DESCRIPTION
Fix https://github.com/gravitee-io/issues/issues/4380

- [x] Improve Quickstart submenu:
  - [x] Split UI and API version in different pages
  - [x] For API version, add a link to full documentation
- [ ] Installation submenu
  - [ ] Up Kubernetes to place it near 'Run on Docker' -> **not that simple because we are in a subfolder list**
  - [x] Installation/Repositories/Overview: Remove href in table header because it is not readable
- [x] Some links open in current page, it could be cool to open another tab (for external documentation, docker hub...) -> **done manually**