### PR TITLE
feat: auto-enable geoip and user_agent when elasticsearch > 7.x

### DIFF
--- a/pages/apim/3.x/installation-guide/configuration/gateway/installation-guide-gateway-configuration.adoc
+++ b/pages/apim/3.x/installation-guide/configuration/gateway/installation-guide-gateway-configuration.adoc
@@ -4,6 +4,7 @@
 :page-folder: apim/installation-guide/gateway
 :page-description: Gravitee.io API Management - Configuration - Gateway
 :page-keywords: Gravitee.io, API Platform, API Management, API Gateway, oauth2, openid, documentation, manual, guide, reference, api
+:page-liquid:
 :page-layout: apim3x
 
 include::../../partial/how-to-configure.adoc[leveloffset=+1]
@@ -275,5 +276,5 @@ Various properties can be specified inside your `GRAVITEE_HOME/config/gravitee.y
 
 [source,yaml]
 ----
-include::https://raw.githubusercontent.com/gravitee-io/gravitee-gateway/3.4.x/gravitee-gateway-standalone/gravitee-gateway-standalone-distribution/src/main/resources/config/gravitee.yml[]
+include::https://raw.githubusercontent.com/gravitee-io/gravitee-gateway/{{ site.products.apim._3x.version }}/gravitee-gateway-standalone/gravitee-gateway-standalone-distribution/src/main/resources/config/gravitee.yml[]
 ----


### PR DESCRIPTION
Fixes https://github.com/gravitee-io/issues/issues/4744

⚠️ the reference to gravitee.yml does not exist for the moment (3.6.x)