### PR TITLE
[#5019] Add authSource option to MongoDB configuration example

### DIFF
--- a/pages/apim/3.x/installation-guide/configuration/repositories/installation-guide-repositories-mongodb.adoc
+++ b/pages/apim/3.x/installation-guide/configuration/repositories/installation-guide-repositories-mongodb.adoc
@@ -52,6 +52,7 @@ management:
     port:                       # mongodb port (default 27017)
     username:                   # mongodb username (default null)
     password:                   # mongodb password (default null)
+    authSource:                 # mongodb authentication source (default gravitee)
     connectionPerHost:          # mongodb connection per host (default 10)
     connectTimeOut:             # mongodb connection time out (default 0 -> never)
     maxWaitTime:                # mongodb max wait time (default 120000)


### PR DESCRIPTION
In relation to https://github.com/gravitee-io/issues/issues/5019.

This PR just adds the `authSource` option to the MongoDB configuration example.