### PR TITLE
ci: build documentation for each PR

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,32 @@
+version: 2.1
+
+jobs:
+  build:
+    docker:
+      - image: cimg/ruby:2.7
+    environment:
+      BUNDLE_PATH: ~/repo/vendor/bundle
+    steps:
+      - checkout
+      - restore_cache:
+          keys:
+            - rubygems-v1-{{ checksum "Gemfile.lock" }}
+            - rubygems-v1-fallback
+      - run:
+          name: Bundle Install
+          command: bundle check || bundle install
+      - save_cache:
+          key: rubygems-v1-{{ checksum "Gemfile.lock" }}
+          paths:
+            - vendor/bundle
+      - run:
+          name: Jekyll build
+          command: bundle exec jekyll build
+      - persist_to_workspace:
+          root: ./
+          paths:
+            - _site
+workflows:
+  test:
+    jobs:
+      - build


### PR DESCRIPTION
**Issue**

NA

**Description**

Setup CI to build the documentation on each PR to avoid any formatting error to be merged to `develop` and then `master`.

**Screenshots**


Example of failing build: 
https://app.circleci.com/pipelines/github/gravitee-io/gravitee-docs/4/workflows/fe6679d6-4696-4811-b804-eb16a0a43e7e/jobs/4

![image](https://user-images.githubusercontent.com/4112568/128075871-9d1d8ed9-d7fd-4b30-addb-98d3c7e0f87f.png)

![image](https://user-images.githubusercontent.com/4112568/128075818-812e2cd4-299f-473a-8e12-65d09eb1a96a.png)




