### PR TITLE
fix(cockpit): wrong link on home page

### DIFF
--- a/index.adoc
+++ b/index.adoc
@@ -52,5 +52,5 @@
 * link:/cockpit/3.x/cockpit_quickstart_getstarted.html[Quick Start Guide]
 * link:/cockpit/3.x/cockpit_installguide_introduction.html[Installation Guide]
 * link:/cockpit/3.x/cockpit_configurationguide.html[Configuration Guide]
-* link:/cockpit/3.x/cockpit_userguide_introduction.html[User Guide]
+* link:/cockpit/3.x/cockpit_userguide_register_installations.html[User Guide]
 * link:/cockpit/3.x/cockpit_changelog.html[Changelog]


### PR DESCRIPTION
**Issue**

N.A.

**Description**

Fix wrong link on home page