### PR TITLE
docs(ae): add doc on how to send events over http

### DIFF
--- a/pages/ae/am/am-installation.adoc
+++ b/pages/ae/am/am-installation.adoc
@@ -59,3 +59,28 @@ AE node and the other nodes from the cluster will be automatically registered.
 
 .Alert Engine - Auto-discovery
 image::ae/howitworks/discovery.png[Discovery mode]
+
+=== Event sending mode
+Starting from v1.5.1 of the alert engine connector, it is possible to configure the connection to send events either over WebSocket (default), either over Http.
+
+On environment with high throughput (~1000 rps), we highly recommend configuring the event sending over http in order to benefit from a good load balancing and load repartition.
+
+Enabling this feature comes with some configuration tuning:
+
+```yaml
+alerts:
+  alert-engine:
+    ws:
+      sendEventsOnHttp: true # Indicates if events should be sent over http or not.
+      connectTimeout: 2000   # Request timeout (useful when relying on http to send events). Default is 2000ms.
+      idleTimeout: 120000    # Idle timeout. After this duration, the connection will be released.
+      keepAlive: true        # Indicates if connection keep alive is enabled or not.
+      pipelining: true       # Indicates if pipelining is enabled or not. When pipelining is enabled, multiple event packets will be sent in a single connection without waiting for the previous responses. Enabling pipeline can increase performances.
+      tryCompression: true   # Indicates if compression is enabled when sending events. The compression must also be enabled on alert engine ingester.
+      maxPoolSize: 50        # Set the maximum number of connections (useful when relying on http to send events).
+      bulkEventsSize: 100    # Events will be sent by packet of 100 events.
+      bulkEventsWait: 100    # Set the duration to wait for bulk events to be ready for sending. When set to 100ms with event size of 100, it means that we will wait for 100 events to be ready to be sent during 100ms. After this period of time, events will be sent event if there are less than 100 events to send.
+```
+
+CAUTION: By default, to keep the same behavior of the previous version, events are sent over a websocket connection.
+The default behavior will switch to http in a next future version.

--- a/pages/ae/apim/apim-installation.adoc
+++ b/pages/ae/apim/apim-installation.adoc
@@ -59,3 +59,28 @@ You can use discovery mode when running an AE cluster to automatically register 
 
 .Alert Engine - Auto-discovery
 image::ae/howitworks/discovery.png[Discovery mode]
+
+=== Event sending mode
+Starting from v1.5.1 of the alert engine connector, it is possible to configure the connection to send events either over WebSocket (default), either over Http.
+
+On environment with high throughput (~1000 rps), we highly recommend configuring the event sending over http in order to benefit from a good load balancing and load repartition.
+
+Enabling this feature comes with some configuration tuning:
+
+```yaml
+alerts:
+  alert-engine:
+    ws:
+      sendEventsOnHttp: true # Indicates if events should be sent over http or not.
+      connectTimeout: 2000   # Request timeout (useful when relying on http to send events). Default is 2000ms.
+      idleTimeout: 120000    # Idle timeout. After this duration, the connection will be released.
+      keepAlive: true        # Indicates if connection keep alive is enabled or not.
+      pipelining: true       # Indicates if pipelining is enabled or not. When pipelining is enabled, multiple event packets will be sent in a single connection without waiting for the previous responses. Enabling pipeline can increase performances.
+      tryCompression: true   # Indicates if compression is enabled when sending events. The compression must also be enabled on alert engine ingester.
+      maxPoolSize: 50        # Set the maximum number of connections (useful when relying on http to send events).
+      bulkEventsSize: 100    # Events will be sent by packet of 100 events.
+      bulkEventsWait: 100    # Set the duration to wait for bulk events to be ready for sending. When set to 100ms with event size of 100, it means that we will wait for 100 events to be ready to be sent during 100ms. After this period of time, events will be sent event if there are less than 100 events to send.
+```
+
+CAUTION: By default, to keep the same behavior of the previous version, events are sent over a websocket connection.
+The default behavior will switch to http in a next future version.


### PR DESCRIPTION
**Issue**

gravitee-io/gravitee-alert-engine/issues/232

**Description**

Documentation on how to configure the AE connector on APIM and AM to enable sending events to AE using http instead of websocket.

