### PR TITLE
docs(ae): fix ae minimum version for http events to 1.5.0

### DIFF
--- a/pages/ae/am/am-installation.adoc
+++ b/pages/ae/am/am-installation.adoc
@@ -61,7 +61,7 @@ AE node and the other nodes from the cluster will be automatically registered.
 image::ae/howitworks/discovery.png[Discovery mode]
 
 === Event sending mode
-Starting from v1.5.1 of the alert engine connector, it is possible to configure the connection to send events either over WebSocket (default), either over Http.
+Starting from v1.5.0 of the alert engine connector, it is possible to configure the connection to send events either over WebSocket (default), either over Http.
 
 On environment with high throughput (~1000 rps), we highly recommend configuring the event sending over http in order to benefit from a good load balancing and load repartition.
 

--- a/pages/ae/apim/apim-installation.adoc
+++ b/pages/ae/apim/apim-installation.adoc
@@ -61,7 +61,7 @@ You can use discovery mode when running an AE cluster to automatically register 
 image::ae/howitworks/discovery.png[Discovery mode]
 
 === Event sending mode
-Starting from v1.5.1 of the alert engine connector, it is possible to configure the connection to send events either over WebSocket (default), either over Http.
+Starting from v1.5.0 of the alert engine connector, it is possible to configure the connection to send events either over WebSocket (default), either over Http.
 
 On environment with high throughput (~1000 rps), we highly recommend configuring the event sending over http in order to benefit from a good load balancing and load repartition.
 


### PR DESCRIPTION
Version of AE needed to send event over http is 1.5.0 not 1.5.1