### PR TITLE
fix: am version in ee docker installation

### DIFF
--- a/pages/ee/installation-guide/installation-guide-docker.adoc
+++ b/pages/ee/installation-guide/installation-guide-docker.adoc
@@ -37,15 +37,15 @@ All the Docker images for Gravitee.io APIM and AM are available with an `-ee` su
 |Image name |Tag |Base
 
 |{docker-hub}/am-gateway/[graviteeio/am-gateway^]
-|{{ site.products.apim.ee.version }}-ee
+|{{ site.products.am.ee.version }}-ee
 |https://hub.docker.com/r/adoptopenjdk/openjdk11/[openjdk:jre-11.0.11_9-alpine^]
 
-|{docker-hub}/am-management-api/[graviteeio/apim-management-api^]
-|{{ site.products.apim.ee.version }}-ee
+|{docker-hub}/am-management-api/[graviteeio/am-management-api^]
+|{{ site.products.am.ee.version }}-ee
 |https://hub.docker.com/r/adoptopenjdk/openjdk11/[openjdk:jre-11.0.11_9-alpine^]
 
-|{docker-hub}/am-management-ui/[graviteeio/apim-management-ui^]
-|{{ site.products.apim.ee.version }}-ee
+|{docker-hub}/am-management-ui/[graviteeio/am-management-ui^]
+|{{ site.products.am.ee.version }}-ee
 |https://hub.docker.com/_/nginx/[nginx:alpine^]
 
 |===


### PR DESCRIPTION
AM version is wrong in the EE docker installation guide. The APIM version is used instead of AM.