### PR TITLE
docs(cert): support for auto reload certificate when updated

### DIFF
--- a/_data/sidebars/apim_3_x_sidebar.yml
+++ b/_data/sidebars/apim_3_x_sidebar.yml
@@ -10,7 +10,7 @@ entries:
         folderitems:
           - title: Introduction
             output: web
-            url: /apim/3.x/apim_overview_introduction.html
+            url: /apim/3.x/overview/introduction.html
             type: homepage
           - title: Architecture
             output: web

--- a/_data/sidebars/cockpit_sidebar.yml
+++ b/_data/sidebars/cockpit_sidebar.yml
@@ -85,6 +85,9 @@ entries:
       - title: Installation health check
         output: web
         url: /cockpit/3.x/cockpit_userguide_installation_health_check.html
+      - title: Create API models with API Designer
+        output: web
+        url: /cockpit/3.x/cockpit_userguide_api_designer.html
   - title: Changelog
     output: web
     folderitems:

--- a/pages/am/3.x/user-guide/mfa/user-guide-mfa-step_up.adoc
+++ b/pages/am/3.x/user-guide/mfa/user-guide-mfa-step_up.adoc
@@ -30,11 +30,10 @@ Step-up authentication is often used in the following scenarios:
 - Users initiate a payment.
 - Users want to delegate access to third parties.
 
-== Configure step-up authentication
-
-. In AM Console, select your application.
-. Click the **Settings** tab, then click **Multifactor Auth**.
-. Set the *Step up authentication* rule.
+. link:/am/current/am_userguide_authentication.html[Log in to AM Console^].
+. Select your application
+. Click *Settings > Multifactor Auth*.
+. Select your MFA factor and set the *Step up authentication* rule.
 . Click *SAVE*.
 +
 image::am/current/graviteeio-am-userguide-mfa-step-up.png[]

--- a/pages/apim/3.x/installation-guide/configuration/gateway/installation-guide-gateway-configuration.adoc
+++ b/pages/apim/3.x/installation-guide/configuration/gateway/installation-guide-gateway-configuration.adoc
@@ -54,19 +54,12 @@ keytool -genkey \
   -storepass secret
 ----
 
-You then need to enable secure mode in `gravitee.yml`:
+===== File keystore
+
+You then need to enable secure mode in `gravitee.yml` and provide a path pointing to the keystore containing the certificate and the associated private key:
 ----
 http:
-  port: 8082
-  host: 0.0.0.0
-  idleTimeout: 0
-  tcpKeepAlive: true
-  compressionSupported: false
-  maxHeaderSize: 8192
-  maxChunkSize: 8192
-  instances: 0
-  requestTimeout: 30000
-  alpn: false
+  # ... skipped for simplicity
   secured: true
   ssl:
     clientAuth: none # Supports none, request, requires
@@ -77,6 +70,34 @@ http:
       path:
       password:
 ----
+
+NOTE: since APIM v3.13.0, the keystore file is automatically watched for any modifications and reloaded without having to restart the gateway server.
+
+===== Kubernetes Secret/ConfigMap keystore
+
+Since v3.13.0, it is possible to load the keystore directly from Kubernetes secret or configmap by just specifying the appropriate location.
+
+----
+http:
+  # ... skipped for simplicity
+  secured: true
+  ssl:
+    clientAuth: none # Supports none, request, requires
+    keystore:
+      type: pkcs12
+      location: /my-namespace/secrets/my-secret/keystore
+      password: adminadmin
+----
+
+The expected `http.ssl.keystore.location` if structured as follows: `/{namespace}/{type}/{name}/{key}`
+With:
+
+- `namespace`: the name of the targeted Kubernetes namespace
+- `type`: can be either `secrets` either `configmaps`, depending on the type of Kubernetes resources to retrieve
+- `name`: the name of the secret or configmap to retrieve
+- `key`: the name of the key holding the value to retrieve. The `key` is optional when using a standard `kubernetes.io/tls` secret (note: it only supports PEM cert & key). The `key` is mandatory for any `Opaque` secret or configmap (note: they only support JKS & PKC12 keystore type).
+
+NOTE: The keystore (or PEM cert & key) stored in the Kubernetes secret or configmap is automatically watched for any modifications and reloaded without having to restart the gateway server.
 
 ==== Enable HTTP/2 support
 


### PR DESCRIPTION
**Issue**

gravitee-io/issues#5888

**Description**

Document the ability to configure gateway keystore (to enable SSL) using either file or kubernetes (secret or configmap)