### PR TITLE
fix: ruby gem build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,7 +20,7 @@ RUN apt-get clean
 RUN mv /var/lib/apt/lists /var/lib/apt/lists.broke
 RUN mkdir -p /var/lib/apt/lists/partial
 RUN apt-get update
-RUN apt-get install -y  nodejs
+RUN apt-get install -y nodejs build-essential
 
 WORKDIR /src
 

--- a/Dockerfile-build
+++ b/Dockerfile-build
@@ -23,7 +23,7 @@ RUN apt-get clean \
 RUN apt-get update
 
 RUN apt-get install -y \
-    nodejs \
+    nodejs build-essential \
   && apt-get clean \
   && rm -rf /var/lib/apt/lists/
 


### PR DESCRIPTION
**Issue**

Ruby Gem build is failing due to the image change which doesn't include the `build-essential` utilities.

I have added the required package in part of the Dockerfiles which should now allow for the Dockerfiles to be build.
