### PR TITLE
docs: password policy dictionary and user profile

### DIFF
--- a/pages/am/3.x/user-guide/user-management/password/user-guide-password-policy.adoc
+++ b/pages/am/3.x/user-guide/user-management/password/user-guide-password-policy.adoc
@@ -27,14 +27,15 @@ You can set the following password characteristics:
 - *Numbers*: must include at least one number.
 - *Special characters*: must include at least one special character.
 - *Mixed case*: must include lower and upper case letters.
-- *Exclude common passwords*: will exclude common passwords from a dictionary
+- *Exclude common passwords*: will exclude common passwords from a dictionary.
 - *Exclude user profile information from passwords*: will user profile information within passwords (case insensitive).
 
 == Password dictionary
 
-By default, the password dictionary includes link:https://github.com/danielmiessler/SecLists/blob/master/Passwords/Common-Credentials/10k-most-common.txt[ten thousand common passwords]
+By default, the password dictionary includes link:https://github.com/danielmiessler/SecLists/blob/master/Passwords/Common-Credentials/10k-most-common.txt[ten thousand common passwords^].
 
-If you wish to use your own password dictionary or complete the one this one go to your `gravitee.yml` (both management and gateway)
+If you wish to use your own password dictionary or add entries to the existing password dictionary, update the `gravitee.yml` file (on both AM Gateway and AM API) as follows:
+
 ```yaml
 user:
   password:
@@ -48,8 +49,10 @@ user:
         watch: true # true|false:boolean
 ```
 
-- `user.password.policy.dictionary.filename`: path of the file containing the passwords
-- `user.password.policy.dictionary.watch`: if true, will listen to any change on the current `filename` to update the dictionary without restarting the service
+Where:
+
+- `user.password.policy.dictionary.filename` is the path of the file containing the passwords.
+- `user.password.policy.dictionary.watch` if true, will listen for any change on the current `filename` and update the dictionary without restarting the service.
 
 == Custom UI errors
 

--- a/pages/am/3.x/user-guide/user-management/password/user-guide-password-policy.adoc
+++ b/pages/am/3.x/user-guide/user-management/password/user-guide-password-policy.adoc
@@ -27,18 +27,43 @@ You can set the following password characteristics:
 - *Numbers*: must include at least one number.
 - *Special characters*: must include at least one special character.
 - *Mixed case*: must include lower and upper case letters.
+- *Exclude common passwords*: will exclude common passwords from a dictionary
+- *Exclude user profile information from passwords*: will user profile information within passwords (case insensitive).
+
+== Password dictionary
+
+By default, the password dictionary includes link:https://github.com/danielmiessler/SecLists/blob/master/Passwords/Common-Credentials/10k-most-common.txt[ten thousand common passwords]
+
+If you wish to use your own password dictionary or complete the one this one go to your `gravitee.yml` (both management and gateway)
+```yaml
+user:
+  password:
+    policy:
+      ...
+      ## Password dictionary to exclude most commons passwords
+      ## You need to enable the feature in the AM management console
+
+      dictionary:
+        filename: /path/to/dictionary.txt
+        watch: true # true|false:boolean
+```
+
+- `user.password.policy.dictionary.filename`: path of the file containing the passwords
+- `user.password.policy.dictionary.watch`: if true, will listen to any change on the current `filename` to update the dictionary without restarting the service
 
 == Custom UI errors
 
 You can access the password policy settings in your *Sign Up* and *Register* link:/am/current/am_userguide_user_management_forms.html[HTML templates^], making it possible to customize the error messages your end users see.
 
-----
-<div th:if="${passwordSettings != null}">
-  <span>Password policy :</span>
-  <p th:if="${passwordSettings.minLength != null}">Contains at least <span th:text="${passwordSettings.minLength}"/> characters</p>
-  <p th:if="${passwordSettings.includeNumbers}">Contains a number</p>
-  <p th:if="${passwordSettings.includeSpecialCharacters}">Contains a special character</p>
-  <p th:if="${passwordSettings.lettersInMixedCase}">Contains letters in mixed case</p>
-  <p th:if="${passwordSettings.maxConsecutiveLetters != null}">Max <span th:text="${passwordSettings.maxConsecutiveLetters}"/> consecutive letters or numbers</p>
+```html
+<div th:if="${passwordSettings != null}" id="passwordSettings">
+    <span>Password policy :</span>
+    <p th:if="${passwordSettings.minLength != null}" id="minLength" class="invalid">Contains at least <span th:text="${passwordSettings.minLength}"/> characters</p>
+    <p th:if="${passwordSettings.includeNumbers}" id="includeNumbers" class="invalid">Contains a number</p>
+    <p th:if="${passwordSettings.includeSpecialCharacters}" id="includeSpecialChar" class="invalid">Contains a special character</p>
+    <p th:if="${passwordSettings.lettersInMixedCase}" id="mixedCase" class="invalid">Contains letters in mixed case</p>
+    <p th:if="${passwordSettings.maxConsecutiveLetters != null}" id="maxConsecutiveLetters" class="valid">Max <span th:text="${passwordSettings.maxConsecutiveLetters}"/> consecutive letters or numbers</p>
+    <p th:if="${passwordSettings.excludePasswordsInDictionary}" id="excludePasswordsInDictionary" class="advice">Don't use common names or passwords</p>
+    <p th:if="${passwordSettings.excludeUserProfileInfoInPassword}" id="excludeUserProfileInfoInPassword" class="invalid">Don't use your profile information in password</p>
 </div>
-----
+```


### PR DESCRIPTION
**Issue**
Password policies: 
https://github.com/gravitee-io/issues/issues/6520
https://github.com/gravitee-io/issues/issues/6521

**Description**

Added documentation to Password policy dictionary and user profile 

**Screenshots**

![localhost_4000_am_current_am_userguide_user_management_password_policy html](https://user-images.githubusercontent.com/8531515/142902094-ed1aea42-37a6-4367-839e-613e3a7c98a5.png)

**Additional context**

https://github.com/gravitee-io/gravitee-access-management/pull/1456
https://github.com/gravitee-io/gravitee-access-management/pull/1459
