### PR TITLE
feat: exclude full_profile with openid only

### DIFF
--- a/_data/sidebars/am_3_x_sidebar.yml
+++ b/_data/sidebars/am_3_x_sidebar.yml
@@ -562,6 +562,9 @@ entries:
             output: web
             url: /am/current/am_breaking_changes.html
             type: homepage
+          - title: Breaking changes in 3.15
+            output: web
+            url: /am/current/am_breaking_changes_3.15.html
           - title: Breaking changes in 3.12
             output: web
             url: /am/current/am_breaking_changes_3.12.html

--- a/pages/am/3.x/breaking-changes/breaking-changes-3.15.adoc
+++ b/pages/am/3.x/breaking-changes/breaking-changes-3.15.adoc
@@ -1,0 +1,15 @@
+= Breaking changes in 3.15
+:page-sidebar: am_3_x_sidebar
+:page-permalink: am/current/am_breaking_changes_3.15.html
+:page-folder: am/installation-guide
+:page-layout: am
+
+== OpenId Connect: `openid` and `full_profile`
+
+Until now, whenever a user consented to the `openid` scope:
+
+* If no requested claim was provided, the `full_profile` scope was implicit
+* Otherwise only the requested claims were provided
+
+From now on, you will have to explicitly request the `full_profile` scope claim to get the entire user profile information.
+


### PR DESCRIPTION
**Issue**

https://github.com/gravitee-io/issues/issues/6516

**Description**
`openid` does not imply `full_profile` anymore

https://github.com/gravitee-io/gravitee-access-management/pull/1480
