### PR TITLE
docs: SCIM role mapper warning

### DIFF
--- a/pages/am/3.x/user-guide/identity-provider/user-guide-mapping-identity-provider.adoc
+++ b/pages/am/3.x/user-guide/identity-provider/user-guide-mapping-identity-provider.adoc
@@ -86,6 +86,9 @@ In addition, when it comes to fine grained authorization management, it is consi
 
 The goal is to dynamically add scopes to the `access_token`, depending on the role associated with the user when authenticating.
 
+WARNING: When the roles are updated via SCIM, the roles already applied via Role Mappers won't be persisted as an assigned role in order
+to safely remove it when the mapper rule does not match anymore. More about SCIM link:/am/current/am_devguide_protocols_scim_overview.html[here^] +
+
 === Example
 
 In the following example, we will map a role named `administrator` to users who are members of the `IT_DEVELOPERS_TEAM` LDAP group. +

--- a/pages/am/3.x/user-guide/identity-provider/user-guide-mapping-identity-provider.adoc
+++ b/pages/am/3.x/user-guide/identity-provider/user-guide-mapping-identity-provider.adoc
@@ -86,8 +86,7 @@ In addition, when it comes to fine grained authorization management, it is consi
 
 The goal is to dynamically add scopes to the `access_token`, depending on the role associated with the user when authenticating.
 
-WARNING: When the roles are updated via SCIM, the roles already applied via Role Mappers won't be persisted as an assigned role in order
-to safely remove it when the mapper rule does not match anymore. More about SCIM link:/am/current/am_devguide_protocols_scim_overview.html[here^] +
+WARNING: When the roles are updated via SCIM, the roles already applied via Role Mappers won't be persisted as an assigned role. This ensures that it can be safely removed when the mapper rule does not match anymore. For more about SCIM, click link:/am/current/am_devguide_protocols_scim_overview.html[here^] +
 
 === Example
 


### PR DESCRIPTION
**Issue**

https://github.com/gravitee-io/issues/issues/6515

**Description**

The issue aims to separate roles given from Identity Provider role mappers to the assigned roles.

**Screenshots**

![Screenshot 2021-12-13 at 10 09 47](https://user-images.githubusercontent.com/8531515/145785601-084f26c3-bedb-429e-bcc2-a325e34bcd03.png)

**Additional context**

https://github.com/gravitee-io/gravitee-access-management/pull/1469
