### PR TITLE
doc(metrics): add configuration to use old labels

### DIFF
--- a/pages/node/partial/metrics.adoc
+++ b/pages/node/partial/metrics.adoc
@@ -49,9 +49,11 @@ In general, it is fine to enable labels when the set of possible values is bound
 
 Default values are `local`, `http_method` and `http_code`.
 
-Starting from APIM 3.10, the metrics labels have been renamed.
-We have introduced a new field in prometheus configuration where you can configure it to use old Vert.X 3 label names.
+Starting from APIM 3.10.0, Vert.x 4 is used and the metrics labels have been renamed.
+We have introduced a new field in prometheus configuration that you can configure to use old Vert.x 3 label names.
 Set it to 3.10, to use old labels.
+
+NOTE: "3.10" in the configuration is related to Vert.x version and not APIM version.
 
 [source,yaml]
 ----

--- a/pages/node/partial/metrics.adoc
+++ b/pages/node/partial/metrics.adoc
@@ -43,14 +43,14 @@ services:
 
 The list of available labels can be found here: https://vertx.io/docs/apidocs/io/vertx/micrometer/Label.html[Label]
 
-WARNING: Enabling labels may result in a high cardinality in values, which can cause troubles on the metrics backend (i.e. the gateway) and affect performances. +
+WARNING: Enabling labels may result in a high cardinality in values, which can cause issues on the metrics backend (i.e. the gateway) and affect performance. +
 So it must be used with care. +
 In general, it is fine to enable labels when the set of possible values is bounded.
 
 Default values are `local`, `http_method` and `http_code`.
 
-Starting from APIM 3.10, the labels of the metrics has been renamed.
-So we have introduced a new field in prometheus configuration to tell it to use old Vert.X 3 label names.
+Starting from APIM 3.10, the metrics labels have been renamed.
+We have introduced a new field in prometheus configuration where you can configure it to use old Vert.X 3 label names.
 Set it to 3.10, to use old labels.
 
 [source,yaml]

--- a/pages/node/partial/metrics.adoc
+++ b/pages/node/partial/metrics.adoc
@@ -49,6 +49,19 @@ In general, it is fine to enable labels when the set of possible values is bound
 
 Default values are `local`, `http_method` and `http_code`.
 
+Starting from APIM 3.10, the labels of the metrics has been renamed.
+So we have introduced a new field in prometheus configuration to tell it to use old Vert.X 3 label names.
+Set it to 3.10, to use old labels.
+
+[source,yaml]
+----
+services:
+  metrics:
+    prometheus:
+      naming:
+        version: 3.10
+----
+
 == Prometheus configuration
 
 The following example requests Prometheus scrape the formatted metrics available in the Gateway internal API.


### PR DESCRIPTION
**Issue**

https://github.com/gravitee-io/issues/issues/6924

**Description**

Add documentation about prometheus configuration and the possibility to choose old label names.

**Screenshots**

![Capture d’écran 2022-01-19 à 19 46 36](https://user-images.githubusercontent.com/13161768/150194718-a81a1e97-9766-4339-9efc-e8a26b32f339.png)

**Additional context**

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->

Not sure about the text or the place in the page. Please comment !!