### PR TITLE
fix: remove Cockpit API Designer doc (not included in 3.15)

### DIFF
--- a/_data/sidebars/cockpit_sidebar.yml
+++ b/_data/sidebars/cockpit_sidebar.yml
@@ -86,9 +86,6 @@ entries:
       - title: Monitor and check the health of installations
         output: web
         url: /cockpit/3.x/cockpit_userguide_installation_health_check.html
-      - title: Create API models with API Designer
-        output: web
-        url: /cockpit/3.x/cockpit_userguide_api_designer.html
   - title: Changelog
     output: web
     folderitems:


### PR DESCRIPTION
**Issue**

N.A.

**Description**

I've noticed that the develop branch have been [merged to master](https://github.com/gravitee-io/gravitee-docs/commit/b563b7e523bd0440e81016225268af4ab2cceb5a). This caused the Cockpit documentation for API Designer to be published on the [docs website](https://docs.gravitee.io/cockpit/3.x/cockpit_userguide_api_designer.html).

But Cockpit API Designer is not available in 3.15 so we need to remove this part of documentation from the website.

I just removed the entry from the menu but kept the pages for the next version.
