### PR TITLE
fix: best match flow mode should select only the best match

### DIFF
--- a/pages/apim/3.x/user-guide/publisher/design-studio/design-studio-create.adoc
+++ b/pages/apim/3.x/user-guide/publisher/design-studio/design-studio-create.adoc
@@ -55,6 +55,18 @@ In the *CONFIGURATION* tab, select *Best match* if you want APIM to match your f
 
 image:{% link images/apim/3.x/api-publisher-guide/design-studio/configuration-tab.png %}[]
 
+Best match flow is chosen if the request matches the flow. A plain text part of the path will take precedence over a path parameter.
+
+It means, reading from left to right, each part of the path is compared, keeping the better matching. Strict equality between part of request path and flow path prevails over a path parameter.
+
+For example, with those flows configured:
+
+- `/test/:id`
+- `/test/subtest`
+
+If the request is `/test/55`, the resulting flow will be `/test/:id`.
+If the request is `/test/subtest`, the resulting flow will be `/test/subtest`.
+
 [[api-properties]]
 === Define properties for your API flows
 


### PR DESCRIPTION
**Issue**

https://github.com/gravitee-io/issues/issues/6654


<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://graviteedocs.blob.core.windows.net/6654-best-match-improvment/index.html)
<!-- UI placeholder end -->
