### PR TITLE
docs: release of 3.16.1

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -120,9 +120,9 @@ products:
     _1x:
       version: 1.30.31
     _3x:
-      version: 3.16.0
+      version: 3.16.1
     ee:
-      version: 3.16.0
+      version: 3.16.1
   am:
     version: 3.16.0
     ee:


### PR DESCRIPTION
Update doc for the 3.16.1 release
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://graviteedocs.blob.core.windows.net/release-3-16-1/index.html)
<!-- UI placeholder end -->
