### PR TITLE
Update documentation for mongodb parameters, notable keystore related

### DIFF
--- a/pages/am/3.x/installation-guide/configuration/installation-guide-configuration.adoc
+++ b/pages/am/3.x/installation-guide/configuration/installation-guide-configuration.adoc
@@ -142,6 +142,9 @@ management:
 #    sslEnabled: false
 #    threadsAllowedToBlockForConnectionMultiplier: 5
 #    cursorFinalizerEnabled: true
+#    keystore:
+#    keystorePassword:
+#    keyPassword
 
 # Management repository: single MongoDB using URI
 # For more information about MongoDB configuration using URI, please have a look to:
@@ -299,6 +302,9 @@ management:
 #    sslEnabled: false
 #    threadsAllowedToBlockForConnectionMultiplier: 5
 #    cursorFinalizerEnabled: true
+#    keystore:
+#    keystorePassword:
+#    keyPassword
 
 # Management repository: single MongoDB using URI
 # For more information about MongoDB configuration using URI, please have a look to:
@@ -404,6 +410,9 @@ management:
     sslEnabled:                 # mongodb ssl mode (default false)
     threadsAllowedToBlockForConnectionMultiplier: # mongodb threads allowed to block for connection multiplier (default null)
     cursorFinalizerEnabled:     # mongodb cursor finalizer enabled (default false)
+    keystore                    # path to KeyStore (when sslEnabled is true, default null)
+    keystorePassword            # KeyStore password (when sslEnabled is true, default null)
+    keyPassword                 # password for recovering keys in the KeyStore (when sslEnabled is true, default null)
 ----
 
 NOTE: All theses properties allow you to fine tuned your MongoDB connection

--- a/pages/am/3.x/installation-guide/configuration/installation-guide-gateway-configuration.adoc
+++ b/pages/am/3.x/installation-guide/configuration/installation-guide-gateway-configuration.adoc
@@ -139,6 +139,9 @@ management:
 #    sslEnabled: false
 #    threadsAllowedToBlockForConnectionMultiplier: 5
 #    cursorFinalizerEnabled: true
+#    keystore:
+#    keystorePassword:
+#    keyPassword
 
 # Management repository: single MongoDB using URI
 # For more information about MongoDB configuration using URI, please have a look to:

--- a/pages/am/3.x/installation-guide/configuration/installation-guide-management-api-configuration.adoc
+++ b/pages/am/3.x/installation-guide/configuration/installation-guide-management-api-configuration.adoc
@@ -188,6 +188,9 @@ management:
 #    sslEnabled: false
 #    threadsAllowedToBlockForConnectionMultiplier: 5
 #    cursorFinalizerEnabled: true
+#    keystore:
+#    keystorePassword:
+#    keyPassword
 
 # Management repository: single MongoDB using URI
 # For more information about MongoDB configuration using URI, please have a look to:

--- a/pages/am/3.x/installation-guide/configuration/installation-guide-repositories-mongodb.adoc
+++ b/pages/am/3.x/installation-guide/configuration/installation-guide-repositories-mongodb.adoc
@@ -60,4 +60,7 @@ management:
     sslEnabled:                 # mongodb ssl mode (default false)
     threadsAllowedToBlockForConnectionMultiplier: # mongodb threads allowed to block for connection multiplier (default null)
     cursorFinalizerEnabled:     # mongodb cursor finalizer enabled (default false)
+    keystore                    # path to KeyStore (when sslEnabled is true, default null)
+    keystorePassword            # KeyStore password (when sslEnabled is true, default null)
+    keyPassword                 # password for recovering keys in the KeyStore (when sslEnabled is true, default null)
 ----

--- a/pages/apim/3.x/installation-guide/configuration/gateway/installation-guide-gateway-configuration.adoc
+++ b/pages/apim/3.x/installation-guide/configuration/gateway/installation-guide-gateway-configuration.adoc
@@ -188,6 +188,9 @@ management:
 #    sslEnabled: false
 #    threadsAllowedToBlockForConnectionMultiplier: 5
 #    cursorFinalizerEnabled: true
+#    keystore:
+#    keystorePassword:
+#    keyPassword
 
 # Management repository: single MongoDB using URI
 # For more information about MongoDB configuration using URI, please have a look to:

--- a/pages/apim/3.x/installation-guide/configuration/rest-apis/installation-guide-rest-apis-configuration.adoc
+++ b/pages/apim/3.x/installation-guide/configuration/rest-apis/installation-guide-rest-apis-configuration.adoc
@@ -179,6 +179,9 @@ management:
 #    sslEnabled: false
 #    threadsAllowedToBlockForConnectionMultiplier: 5
 #    cursorFinalizerEnabled: true
+#    keystore:
+#    keystorePassword:
+#    keyPassword
 
 # Management repository: single MongoDB using URI
 # For more information about MongoDB configuration using URI, please have a look to:

--- a/pages/cockpit/configuration-guide/installation-guide-configuration.adoc
+++ b/pages/cockpit/configuration-guide/installation-guide-configuration.adoc
@@ -177,6 +177,9 @@ management:
 #    writeConcern: 1
 #    wtimeout: 0
 #    journal: true
+#    keystore:
+#    keystorePassword:
+#    keyPassword
 ds:
   mongodb:
     dbname: gravitee-cockpit


### PR DESCRIPTION
**Description**

The mongodb configuration is missing the keystore parameters in a lot of places, especially where the full documentation should be.


**Additional context**

Documents the changes done in https://github.com/gravitee-io/gravitee-repository-mongodb/pull/83 

