### PR TITLE
docs: add missing breaking changes

### DIFF
--- a/pages/apim/3.x/installation-guide/installation-guide-migration.adoc
+++ b/pages/apim/3.x/installation-guide/installation-guide-migration.adoc
@@ -41,6 +41,8 @@ include::upgrades/3.11.1/README.adoc[leveloffset=+1]
 
 include::upgrades/3.11.0/README.adoc[leveloffset=+1]
 
+include::upgrades/3.10.13/README.adoc[leveloffset=+1]
+
 include::upgrades/3.10.9/README.adoc[leveloffset=+1]
 
 include::upgrades/3.10.8/README.adoc[leveloffset=+1]

--- a/pages/apim/3.x/installation-guide/upgrades/3.10.13/README.adoc
+++ b/pages/apim/3.x/installation-guide/upgrades/3.10.13/README.adoc
@@ -1,0 +1,11 @@
+= Upgrade to 3.10.13
+
+== Breaking Change
+
+=== Docker Images - Enterprise Edition
+
+To reduce the number of security vulnerabilities and ensure a better maintenance in the future, the base Docker images used for the Enterprise Edition have changed.
+
+As of 3.10.13, APIM Gateway EE and Management API EE base Docker images are moving from **Ubuntu** to **Alpine** with JDK 17. It means users creating their own Docker images based on the one provided by Gravitee.io might need to update their Dockerfile to make them compatible with the Alpine distribution.
+
+_Notes_: Community Edition users will not be affected as the base images were already **Alpine** ones.


### PR DESCRIPTION
docker breaking change for 3.10.13
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://graviteedocs.blob.core.windows.net/apim-3-10-13-breaking/index.html)
<!-- UI placeholder end -->
