### PR TITLE
docs: 3.18 upgrade note about platform alerts scoped to environment

### DIFF
--- a/pages/apim/3.x/installation-guide/installation-guide-migration.adoc
+++ b/pages/apim/3.x/installation-guide/installation-guide-migration.adoc
@@ -13,6 +13,8 @@ You may be required to perform manual actions as part of the upgrade.
 WARNING: Be sure to run scripts on the correct database since `gravitee` is not always the default database!
 Check your db name by running `show dbs;`
 
+include::upgrades/3.18.0/README.adoc[leveloffset=+1]
+
 include::upgrades/3.17.0/README.adoc[leveloffset=+1]
 
 include::upgrades/3.16.2/README.adoc[leveloffset=+1]

--- a/pages/apim/3.x/installation-guide/upgrades/3.18.0/README.adoc
+++ b/pages/apim/3.x/installation-guide/upgrades/3.18.0/README.adoc
@@ -1,0 +1,12 @@
+= Upgrade to 3.18.0
+
+=== Platform alerts on multi-environments APIM
+
+Before this version, platform alerts were common to all environments.
+That led to inconsistencies while handling platform alerts on multi-environments APIM.
+
+From this version, platform alerts are scoped to the environment.
+For example, if you create an alert on your `production` environment, it is related only to this environment.
+
+Old platform alerts existing before Gravitee upgrade will be linked to the default environment.
+You will see them disappear from your others (non-default) environments, and will have to recreate them manually if relevant.


### PR DESCRIPTION
**Issue**

https://github.com/gravitee-io/issues/issues/6079
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://graviteedocs.blob.core.windows.net/docs-alertsscopetoenv-upgradenote/index.html)
<!-- UI placeholder end -->
