### PR TITLE
docs(apim): add warning on return content instruction

### DIFF
--- a/pages/apim/3.x/policy-reference/policy-javascript.adoc
+++ b/pages/apim/3.x/policy-reference/policy-javascript.adoc
@@ -113,6 +113,8 @@ And the request body being passed to the API would be:
 ]
 ----
 
+WARNING: When working with scripts on onRequestContent phase, the last instruction of the script **must be** the new body content that would be returned by the policy.
+
 == Phase - onResponse
 In the **onResponse** phase you have access to the **request**, the **response** and the **context** object.
 |===
@@ -154,6 +156,9 @@ And the reponse message would be:
     }
 ]
 ----
+
+WARNING: When working with scripts on onResponseContent phase, the last instruction of the script **must be** the new body content that would be returned by the policy.
+
 
 == Reference - Metrics [[metricsobject]]
 It is highly advisable to use the link:{% link pages/apim/3.x/policy-reference/policy-metrics-reporter.adoc %}[Metrics Reporter] in order to manage the metrics. However, the request object does contain a **metrics** object.


### PR DESCRIPTION
**Issue**

https://github.com/gravitee-io/issues/issues/7179

**Description**

A small description of what you did in that PR.

**Screenshots**

<!-- If applicable, add screenshots to help explain your problem. -->

**Additional context**

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->

<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://graviteedocs.blob.core.windows.net/update-javascript-policy/index.html)
<!-- UI placeholder end -->
