### PR TITLE
fix: add upgrade script link for 3.17.0

### DIFF
--- a/pages/apim/3.x/installation-guide/upgrades/3.17.0/README.adoc
+++ b/pages/apim/3.x/installation-guide/upgrades/3.17.0/README.adoc
@@ -45,3 +45,10 @@ For the sake of improving our documentation management process, we have started 
 
 As a part of this change, our mongodb upgrade scripts are not hosted inside the release repository anymore and
 have been moved to the link:https://github.com/gravitee-io/gravitee-api-management/tree/master/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/resources/scripts[gravitee-api-management] repository.
+
+=== MongoDB
+
+Before running any script, please create a dump of your existing database.
+
+link:https://raw.githubusercontent.com/gravitee-io/gravitee-api-management/master/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/resources/scripts/3.17.0/api-keys-cleanup.js[/apim/3.x/mongodb/3.17.0/api-keys-cleanup.js]::
+This script performs some cleanup on the keys collection in order to avoid issues while moving to the new model.


### PR DESCRIPTION
see https://github.com/gravitee-io/issues/issues/7610

<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://graviteedocs.blob.core.windows.net/fix-add-upgrade-script-for-3-17/index.html)
<!-- UI placeholder end -->
