### PR TITLE
docs(apim): add note about JDBC rate limit limitations

### DIFF
--- a/pages/apim/3.x/installation-guide/configuration/repositories/installation-guide-repositories.adoc
+++ b/pages/apim/3.x/installation-guide/configuration/repositories/installation-guide-repositories.adoc
@@ -33,7 +33,7 @@ The following matrix shows scope and storage compatibility.
 |X
 |X
 |-
-|X
+|X footnote:[Using JDBC as a rate limit repository is not recommended. It can lead to inaccuracies in limit calculation, as counter is not shared across concurrent threads.]
 
 |Analytics
 |-


### PR DESCRIPTION
**Issue**

https://github.com/gravitee-io/issues/issues/6563

**Description**

docs(apim): add note about JDBC rate limit limitations
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://graviteedocs.blob.core.windows.net/docs-jdbcratelimitlimit/index.html)
<!-- UI placeholder end -->
