### PR TITLE
APIM 3.17.3 has been released

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -120,9 +120,9 @@ products:
     _1x:
       version: 1.30.31
     _3x:
-      version: 3.17.0
+      version: 3.17.3
     ee:
-      version: 3.17.0
+      version: 3.17.3
   am:
     version: 3.17.0
     ee:

--- a/pages/apim/3.x/installation-guide/installation-guide-migration.adoc
+++ b/pages/apim/3.x/installation-guide/installation-guide-migration.adoc
@@ -13,6 +13,8 @@ You may be required to perform manual actions as part of the upgrade.
 WARNING: Be sure to run scripts on the correct database since `gravitee` is not always the default database!
 Check your db name by running `show dbs;`
 
+include::upgrades/3.17.3/README.adoc[leveloffset=+1]
+
 include::upgrades/3.17.0/README.adoc[leveloffset=+1]
 
 include::upgrades/3.16.2/README.adoc[leveloffset=+1]

--- a/pages/apim/3.x/installation-guide/upgrades/3.10.1/README.adoc
+++ b/pages/apim/3.x/installation-guide/upgrades/3.10.1/README.adoc
@@ -2,7 +2,7 @@
 
 == Breaking changes
 
-From with this version, the name of the APIM Rest APIs component changes.
+From this version, the name of the APIM Rest APIs component changes.
 As a consequence:
 
 1. The APIM Rest API component available on https://download.gravitee.io is now `gravitee-*apim*-rest-api-x.y.z.zip` instead of `gravitee-management-rest-api-x.y.z.zip`

--- a/pages/apim/3.x/installation-guide/upgrades/3.17.3/README.adoc
+++ b/pages/apim/3.x/installation-guide/upgrades/3.17.3/README.adoc
@@ -1,0 +1,18 @@
+= Upgrade to 3.17.3
+
+== Breaking changes
+
+From this version, and for the next 3.17.x versions, the name of the Elasticsearch repository component changes. +
+As a consequence, the Elasticsearch repository component available on https://download.gravitee.io is now +
+
+`gravitee-*apim*-repository-elasticsearch-x.y.z.zip` +
+
+instead of +
+
+`gravitee-repository-elasticsearch-x.y.z.zip`
+
+This plugin has also been moved in another folder: https://download.gravitee.io/#graviteeio-apim/plugins/repositories/gravitee-apim-repository-elasticsearch/. +
+
+You can download directly the Elasticsearch repository using this link: +
+https://download.gravitee.io/graviteeio-apim/plugins/repositories/gravitee-apim-repository-elasticsearch/gravitee-apim-repository-elasticsearch-3.17.3.zip
+


### PR DESCRIPTION
**Issue**

N/A

**Description**

APIM 3.17.3 has been released
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://graviteedocs.blob.core.windows.net/integrate-elasticsearch-repository-in-apim/index.html)
<!-- UI placeholder end -->
