### PR TITLE
upgrade note for the ES repository renaming - 3.10.15

### DIFF
--- a/pages/apim/3.x/installation-guide/installation-guide-migration.adoc
+++ b/pages/apim/3.x/installation-guide/installation-guide-migration.adoc
@@ -43,6 +43,8 @@ include::upgrades/3.11.1/README.adoc[leveloffset=+1]
 
 include::upgrades/3.11.0/README.adoc[leveloffset=+1]
 
+include::upgrades/3.10.15/README.adoc[leveloffset=+1]
+
 include::upgrades/3.10.13/README.adoc[leveloffset=+1]
 
 include::upgrades/3.10.9/README.adoc[leveloffset=+1]

--- a/pages/apim/3.x/installation-guide/upgrades/3.10.15/README.adoc
+++ b/pages/apim/3.x/installation-guide/upgrades/3.10.15/README.adoc
@@ -1,0 +1,17 @@
+= Upgrade to 3.10.15
+
+== Breaking changes
+
+From this version, and for the next 3.10.x versions, the name of the Elasticsearch repository component changes. +
+As a consequence, the Elasticsearch repository component available on https://download.gravitee.io is now +
+`gravitee-*apim*-repository-elasticsearch-x.y.z.zip`
+
+instead of +
+`gravitee-repository-elasticsearch-x.y.z.zip`
+
+This plugin has also been moved in another folder: +
+https://download.gravitee.io/#graviteeio-apim/plugins/repositories/gravitee-apim-repository-elasticsearch/.
+
+You can download directly the Elasticsearch repository using this link: +
+https://download.gravitee.io/graviteeio-apim/plugins/repositories/gravitee-apim-repository-elasticsearch/gravitee-apim-repository-elasticsearch-3.10.15.zip
+


### PR DESCRIPTION
**Issue**

https://github.com/gravitee-io/issues/issues/7620

**Description**

add a breaking change note for the renaming of `gravitee-repository-elasticsearch`
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://graviteedocs.blob.core.windows.net/move-reporter-elasticsearch-in-apim-repo-3-10-x/index.html)
<!-- UI placeholder end -->
