### PR TITLE
upgrade note for the ES repository renaming - 3.18.0

### DIFF
--- a/pages/apim/3.x/installation-guide/upgrades/3.18.0/README.adoc
+++ b/pages/apim/3.x/installation-guide/upgrades/3.18.0/README.adoc
@@ -36,3 +36,19 @@ To provide more flexibility in the way roles are managed, some system roles have
 . The Application Primary Owner Role
 
 The Organization Admin Role remains a read-only role. If any accidental loss of access happened to one of the roles listed above, the Organization Admin Role will be the only one able to revert the changes.
+
+=== Plugin renaming
+
+From this version, and for the next 3.18.x versions and greater, the name of the Elasticsearch repository component changes. +
+As a consequence, the Elasticsearch repository component available on https://download.gravitee.io is now +
+`gravitee-*apim*-repository-elasticsearch-x.y.z.zip`
+
+instead of +
+`gravitee-repository-elasticsearch-x.y.z.zip`
+
+This plugin has also been moved in another folder: +
+https://download.gravitee.io/#graviteeio-apim/plugins/repositories/gravitee-apim-repository-elasticsearch/.
+
+You can download directly the Elasticsearch repository using this link: +
+https://download.gravitee.io/graviteeio-apim/plugins/repositories/gravitee-apim-repository-elasticsearch/gravitee-apim-repository-elasticsearch-3.18.0.zip
+


### PR DESCRIPTION
**Issue**

https://github.com/gravitee-io/issues/issues/7620

**Description**

add a breaking change note for the renaming of `gravitee-repository-elasticsearch`
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://graviteedocs.blob.core.windows.net/move-reporter-elasticsearch-in-apim-repo-master/index.html)
<!-- UI placeholder end -->
