### PR TITLE
Update installation-guide-repositories-redis.adoc

### DIFF
--- a/pages/apim/3.x/installation-guide/configuration/repositories/installation-guide-repositories-redis.adoc
+++ b/pages/apim/3.x/installation-guide/configuration/repositories/installation-guide-repositories-redis.adoc
@@ -13,8 +13,6 @@ This repository plugin is for connecting to Redis databases for Rate Limit featu
 
 == Install the Rate Limit repository plugin
 
-NOTE: Because the plugin is part of the default distribution from APIM version 3.5, you only need to complete these steps for version 3.4 or earlier.
-
 Repeat these steps on each component (APIM Gateway and APIM API) where the SQL database is used.
 
 . Download the plugin corresponding to your APIM version (take the latest maintenance release).


### PR DESCRIPTION
Remove false statement.
(Redis is not included by default)
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://graviteedocs.blob.core.windows.net/update-apim-redis-repo-doc/index.html)
<!-- UI placeholder end -->
