### PR TITLE
docs(apim): add note for cache managers in apim 3.19.0 upgrade

### DIFF
--- a/pages/apim/3.x/installation-guide/upgrades/3.19.0/README.adoc
+++ b/pages/apim/3.x/installation-guide/upgrades/3.19.0/README.adoc
@@ -1,0 +1,19 @@
+= Upgrade to 3.19.0
+
+== Breaking changes
+
+=== Custom policies
+
+For users who developed their own policy using `ApiKeyRepository` or `SubscriptionRepository` to retrieve API keys or subscriptions.
+
+In previous versions, those repositories were overridden with a cached implementation, which was returning active API keys and subscriptions only, in an optimized way.
+
+From this version, `ApiKeyRepository` and `SubscriptionRepository` query the database directly without any cache.
+Using them in policies is strongly discouraged.
+
+We recommend using those new components to access the active API keys or subscriptions :
+
+* `io.gravitee.gateway.api.service.ApiKeyService` : _getByApiAndKey_
+* `io.gravitee.gateway.api.service.SubscriptionService` : _getByApiAndClientId_ and _getById_
+
+


### PR DESCRIPTION
**Issue**

https://github.com/gravitee-io/issues/issues/7360

**Description**

docs(apim): add note for cache managers in apim 3.19.0 upgrade
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://graviteedocs.blob.core.windows.net/docs-apikeysandsubsmanagers/index.html)
<!-- UI placeholder end -->
