### PR TITLE
fix: typo in dev-guide

### DIFF
--- a/pages/apim/3.x/dev-guide/dev-guide-boostrap.adoc
+++ b/pages/apim/3.x/dev-guide/dev-guide-boostrap.adoc
@@ -76,7 +76,7 @@ Create a new Run configuration in IntelliJ:
 
 . Click *Run -> Edit configurations -> ✚ -> Application*.
 . Name it as required.
-. Choose *Use classpath of module*: `gravitee-gateway-standalone-container`.
+. Choose *Use classpath of module*: `gravitee-apim-gateway-standalone-container`.
 . Select *Main class*: `io.gravitee.gateway.standalone.GatewayContainer`.
 . In the VM options, add the following (change the path to point to your project):
 +


### PR DESCRIPTION
**Issue**

https://graviteedevops.atlassian.net/browse/DOC-118

**Description**

Change `gravitee-gateway-standalone-container` into `gravitee-apim-gateway-standalone-container` in the dev guide