### PR TITLE
DOC-186 Updated EE versions page to reflect the new support model, an…

### DIFF
--- a/pages/ee/overview/introduction.adoc
+++ b/pages/ee/overview/introduction.adoc
@@ -1,12 +1,11 @@
+[[gravitee-enterprise-api-platform]]
+= Gravitee.io Enterprise API Platform
 :page-sidebar: ee_sidebar
 :page-permalink: ee/ee_introduction.html
 :page-folder: ee/overview
 :page-toc: false
 :page-description: Gravitee Enterprise Edition - Introduction
 :page-keywords: Gravitee, API Platform, Enterprise Edition, documentation, manual, guide, reference, api
-
-[[gravitee-enterprise-api-platform]]
-= Gravitee.io Enterprise API Platform
 
 == Introduction
 
@@ -24,6 +23,6 @@ For this reason, we've decided not to apply any changes to the existing platform
 
 If you're talking with the team on Gitter, you can probably see that we have increasing numbers of questions to answer, business contexts to manage, and features to implement to provide you with the best API platform possible. All of these things take time and, of course, money.
 
-So we've decided to create the Gravitee.io Enterprise API Platform. This version brings many new benefits and exciting features to help you bring effortless control to every aspect of your organization's API ecosystem. 
+So we've decided to create the Gravitee.io Enterprise API Platform. This version brings many new benefits and exciting features to help you bring effortless control to every aspect of your organization's API ecosystem.
 
 We look forward to embarking on this new adventure with you.

--- a/pages/ee/overview/version.adoc
+++ b/pages/ee/overview/version.adoc
@@ -12,7 +12,7 @@
 
 As of version 3.18.0 (released on 7th July 2022), we have changed the model of support we provide for released versions of the Gravitee Platform.
 
-We now provide 12 months of support for each minor version. A minor version is considered a quarterly release release version with a second-digit increment in the version cadence, for example 3.18.x (but not 3.18.1 - this is a maintenance release version).
+We now provide 12 months of support for each minor version. A minor version is considered a quarterly release version with a second-digit increment in the version cadence, for example 3.18.x (but not 3.18.1 - this is a maintenance release version).
 
 We no longer support STS and LTS versions (see the next section for more information).
 

--- a/pages/ee/overview/version.adoc
+++ b/pages/ee/overview/version.adoc
@@ -1,3 +1,4 @@
+= Gravitee.io Enterprise API Platform Versions
 :page-sidebar: ee_sidebar
 :page-permalink: ee/ee_version.html
 :page-folder: ee/overview
@@ -5,90 +6,105 @@
 :page-description: Gravitee Enterprise Edition - Versions
 :page-keywords: Gravitee, API Platform, Enterprise Edition, documentation, manual, guide, reference, api
 
-= Gravitee.io Enterprise API Platform
+== Support policy model
 
-== STS Vs. LTS Support
+=== From version 3.18.0 and above: 12-month support model for all minor versions
 
-When you subscribe to support services provided by Gravitee.io, you can choose between two support options:
+As of version 3.18.0 (released on 7th July 2022), we have changed the model of support we provide for released versions of the Gravitee Platform.
+
+We now provide 12 months of support for each minor version. A minor version is considered a quarterly release release version with a second-digit increment in the version cadence, for example 3.18.x (but not 3.18.1 - this is a maintenance release version).
+
+We no longer support STS and LTS versions (see the next section for more information).
+
+=== Prior to version 3.18.0: STS & LTS support model
+
+Prior to the release of version 3.18.0, when you subscribed to support services provided by Gravitee.io, you could choose between two support options:
 
 . Short-Term Support (STS).
 . Long-Term Support (LTS).
 
-LTS applies to versions ending with 0 or 5 (for example: 1.25, 1.30, 1.35).
-STS applies to all non-LTS versions.
+LTS applied to versions ending with 0 or 5 (for example: 1.25, 1.30, 1.35).
+STS applied to all non-LTS versions.
 
-An LTS version is supported for around 1 year, whereas a STS version is supported for 3 months.
+An LTS version was supported for around 1 year, whereas a STS version was supported for 3 months.
 
-When moving to an enterprise version, this is not the case: **all** LTS versions are considered to be enterprise versions.
+When moving to an enterprise version, this was not the case: **all** LTS versions were considered to be enterprise versions.
 
-What does this mean for you? Simply that you can be sure that you are running the most well-tested and production-ready versions.
+This model aimed to ensure that our customers would be running the most well-tested and production-ready versions.
 
+== Supported product versions and EOL dates
 
-== Supported Versions & EOL Date
+The tables below provide information about product versions and their release and EOL (end of life) dates, as well as the support model used for each.
 
-In the tables below, you'll find information on what versions have been retired and when. Note that the second two tables show a breakdown of individual products, API Management and Access Management (whereas the first table reflects the entire platform).
+Note that the Table 1 and Table 2 reflect the entire Gravitee platform whereas Table 3 and Table 4 show breakdowns for individual products - API Management (APIM) and Access Management (AM).
 
-.Gravitee.io Platform Version 3.0 & Above
+.Gravitee.io current latest platform version
 [width="75%",options="header,footer"]
-|====================
-| Version | Release Date | EOL Date
-| 3.0.x - LTS | 2020-05-20 | 2021-06-15
-| 3.1.x | 2020-07-17 | 2020-10-22
-| 3.2.x | 2020-09-22 | 2020-11-15
-| 3.3.x | 2020-10-15 | 2020-12-24
-| 3.4.x | 2020-11-24 | 2021-01-15
-| 3.5.x - LTS | 2020-12-15 | 2021-12-15
-| 3.6.x | 2021-02-16 | 2021-04-16
-| 3.7.x | 2021-03-16 | 2021-05-13
-| 3.8.x | 2021-04-13 | 2021-06-18
-| 3.9.x | 2021-05-18 | 2021-07-15
-| 3.10.x - LTS | 2021-06-15 | 2022-08-03
-| 3.11.x| 2021-08-31 | 2021-10-31
-| 3.12.x| 2021-09-30 | 2021-12-19
-| 3.13.x| 2021-11-19 | 2022-01-27
-| 3.14.x| 2022-01-12 | 2022-03-30
-| 3.15.x - LTS | 2021-01-27 | 2023-01-31
-| 3.16.x| 2022-02-28 | 2022-04-30
-| 3.17.x| 2022-03-30 | 2022-07-31
-| 3.18.x - LTS | 2022-07-07 | 2023-06-30
-|====================
+|=========================
+| Version | Support model | Release Date | EOL Date
+| *3.18.x* | *12 months* | *2022-07-07* | *2023-07-07*
+|=========================
 
-.Gravitee.io API Management Versions Below 3.0
+.Gravitee.io platform version 3.0.x and above
 [width="75%",options="header,footer"]
-|====================
-| Version | Release Date | EOL Date
-| 1.15.x - LTS | 2018-04-04 | 2019-04-18
-| 1.16.x | 2018-05-10 | 2018-07-15
-| 1.17.x | 2018-06-15 | 2018-08-11
-| 1.18.x | 2018-07-11 | 2018-10-11
-| 1.19.x | 2018-09-11 | 2018-11-18
-| 1.20x - LTS | 2018-10-18 | 2019-10-24
-| 1.21.x | 2018-11-28 | 2019-02-16
-| 1.22.x | 2019-01-16 | 2019-03-25
-| 1.23.x | 2019-02-25 | 2019-04-22
-| 1.24.x | 2019-03-22 | 2019-05-24
-| 1.25.x - LTS | 2019-04-24 | 2020-05-17
-| 1.26.x | 2019-05-21 | 2019-07-19
-| 1.27.x | 2019-06-19 | 2019-08-18
-| 1.28.x | 2019-07-18 | 2019-10-18
-| 1.29.x | 2019-09-18 | 2019-12-17
-| 1.30.x - LTS | 2019-11-17 | 2020-11-20
-|====================
+|=========================
+| Version | Support model | Release Date | EOL Date
+| 3.0.x | *LTS* | 2020-05-20 | 2021-06-15
+| 3.1.x | STS | 2020-07-17 | 2020-10-22
+| 3.2.x | STS | 2020-09-22 | 2020-11-15
+| 3.3.x | STS | 2020-10-15 | 2020-12-24
+| 3.4.x | STS| 2020-11-24 | 2021-01-15
+| 3.5.x | *LTS* | 2020-12-15 | 2021-12-15
+| 3.6.x | STS| 2021-02-16 | 2021-04-16
+| 3.7.x | STS| 2021-03-16 | 2021-05-13
+| 3.8.x | STS| 2021-04-13 | 2021-06-18
+| 3.9.x | STS| 2021-05-18 | 2021-07-15
+| 3.10.x | *LTS* | 2021-06-15 | 2022-07-31
+| 3.11.x | STS | 2021-08-31 | 2021-10-31
+| 3.12.x | STS | 2021-09-30 | 2021-12-19
+| 3.13.x | STS | 2021-11-19 | 2022-01-27
+| 3.14.x | STS | 2022-01-12 | 2022-03-30
+| 3.15.x | *LTS* | 2021-01-27 | 2023-01-31
+| 3.16.x | STS | 2022-02-28 | 2022-04-30
+| 3.17.x | STS | 2022-03-30 | 2022-07-31
+| *3.18.x* | *12 months* | *2022-07-07* | *2023-07-07*
+|=========================
 
-
-.Gravitee.io Access Management Versions 2.x0
+.Gravitee.io API Management (APIM) versions 1.15.x to 1.30.x
 [width="75%",options="header,footer"]
-|====================
-| Version | Release Date | EOL Date
-| 2.0.x - LTS | 2018-07-13 | 2019-10-24
-| 2.1.x | 2018-11-28 | 2019-02-24
-| 2.2.x | 2019-01-24 | 2019-03-25
-| 2.3.x | 2019-02-25 | 2019-04-20
-| 2.4.x | 2019-03-20 | 2019-05-24
-| 2.5.x - LTS | 2019-04-24 | 2020-05-05
-| 2.6.x | 2019-05-24 | 2019-07-15
-| 2.7.x | 2019-06-15 | 2019-08-17
-| 2.8.x | 2019-07-17 | 2019-10-18
-| 2.9.x | 2019-09-18 | 2019-12-05
-| 2.10.x - LTS | 2019-11-05 | 2020-11-20
-|====================
+|=========================
+| Version | Support model | Release Date | EOL Date
+| 1.15.x | *LTS* | 2018-04-04 | 2019-04-18
+| 1.16.x | STS | 2018-05-10 | 2018-07-15
+| 1.17.x | STS | 2018-06-15 | 2018-08-11
+| 1.18.x | STS | 2018-07-11 | 2018-10-11
+| 1.19.x | STS | 2018-09-11 | 2018-11-18
+| 1.20.x | *LTS* | 2018-10-18 | 2019-10-24
+| 1.21.x | STS | 2018-11-28 | 2019-02-16
+| 1.22.x | STS | 2019-01-16 | 2019-03-25
+| 1.23.x | STS | 2019-02-25 | 2019-04-22
+| 1.24.x | STS | 2019-03-22 | 2019-05-24
+| 1.25.x | *LTS* | 2019-04-24 | 2020-05-17
+| 1.26.x | STS | 2019-05-21 | 2019-07-19
+| 1.27.x | STS | 2019-06-19 | 2019-08-18
+| 1.28.x | STS | 2019-07-18 | 2019-10-18
+| 1.29.x | STS | 2019-09-18 | 2019-12-17
+| 1.30.x | *LTS* | 2019-11-17 | 2020-11-20
+|=========================
+
+.Gravitee.io Access Management (AM) versions 2.0.x to 2.10.x
+[width="75%",options="header,footer"]
+|=========================
+| Version | Support model | Release Date | EOL Date
+| 2.0.x | *LTS* | 2018-07-13 | 2019-10-24
+| 2.1.x | STS | 2018-11-28 | 2019-02-24
+| 2.2.x | STS | 2019-01-24 | 2019-03-25
+| 2.3.x | STS | 2019-02-25 | 2019-04-20
+| 2.4.x | STS | 2019-03-20 | 2019-05-24
+| 2.5.x | *LTS* | 2019-04-24 | 2020-05-05
+| 2.6.x | STS | 2019-05-24 | 2019-07-15
+| 2.7.x | STS | 2019-06-15 | 2019-08-17
+| 2.8.x | STS | 2019-07-17 | 2019-10-18
+| 2.9.x | STS | 2019-09-18 | 2019-12-05
+| 2.10.x | *LTS* | 2019-11-05 | 2020-11-20
+|=========================


### PR DESCRIPTION
DOC-186 Updated EE versions page to reflect the new support model, and fixed heading bug in this page and the adjacent Introduction page.

**Issue**

https://graviteedevops.atlassian.net/browse/DOC-186

**Description**

DOC-186 Updated EE versions page to reflect the new support model, and fixed heading bug in this page and the adjacent Introduction page.
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://graviteedocs.blob.core.windows.net/doc-186/index.html)
<!-- UI placeholder end -->
