### PR TITLE
docs: document security chain change in 3.10.19 upgrade note

### DIFF
--- a/pages/apim/3.x/installation-guide/installation-guide-migration.adoc
+++ b/pages/apim/3.x/installation-guide/installation-guide-migration.adoc
@@ -49,6 +49,8 @@ include::upgrades/3.11.1/README.adoc[leveloffset=+1]
 
 include::upgrades/3.11.0/README.adoc[leveloffset=+1]
 
+include::upgrades/3.10.19/README.adoc[leveloffset=+1]
+
 include::upgrades/3.10.15/README.adoc[leveloffset=+1]
 
 include::upgrades/3.10.13/README.adoc[leveloffset=+1]

--- a/pages/apim/3.x/installation-guide/upgrades/3.10.19/README.adoc
+++ b/pages/apim/3.x/installation-guide/upgrades/3.10.19/README.adoc
@@ -1,0 +1,31 @@
+= Upgrade to 3.10.19
+
+== Breaking changes
+
+=== API key and JWT plans
+
+The security chain (the internal process that selects the executable plan for the incoming request and applies the related security rules) parses all active plans to select and execute the relevant one.
+
+**Prior to this version:**
+
+- The API key plan was executed if the request contained an API key.
+- The JWT plan was executed if the request contained a Bearer token.
+
+**From this version:**
+
+The security chain has been improved to select and execute plans more efficiently. As a result, API keys and JWT plans are now only executed if there is an active subscription related to the provided security token. If there is no relevant subscription, the currently parsed plans are not executed and the security chain moves to parse the next available plans. The process continues until the security chain parses plans related to the provided security token and these plans are executed, or until all available plans are parsed without a match.
+
+Specific examples of this change are provided in the table below:
+|===
+| API plans | Request | Prior to this version | From this version
+
+|API key plan + Keyless plan
+|Request contains an invalid API key
+|API key plan is executed = HTTP 401 unauthorized
+|Keyless plan is executed
+
+|JWT plan 1 + JWT plan 2
+|Request contains a Bearer token valid for JWT plan 2
+|JWT plan 1 is executed = HTTP 401 unauthorized
+|JWT plan 2 is executed
+|===


### PR DESCRIPTION
**Issue**

https://github.com/gravitee-io/issues/issues/7824
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://graviteedocs.blob.core.windows.net/docs-plansbreakingchange-3-10/index.html)
<!-- UI placeholder end -->
