### PR TITLE
doc: add a breaking change information for APIM 3.18.5 about portal API

### DIFF
--- a/pages/apim/3.x/installation-guide/installation-guide-migration.adoc
+++ b/pages/apim/3.x/installation-guide/installation-guide-migration.adoc
@@ -13,6 +13,8 @@ You may be required to perform manual actions as part of the upgrade.
 WARNING: Be sure to run scripts on the correct database since `gravitee` is not always the default database!
 Check your db name by running `show dbs;`
 
+include::upgrades/3.18.5/README.adoc[leveloffset=+1]
+
 include::upgrades/3.18.0/README.adoc[leveloffset=+1]
 
 include::upgrades/3.17.3/README.adoc[leveloffset=+1]

--- a/pages/apim/3.x/installation-guide/upgrades/3.18.5/README.adoc
+++ b/pages/apim/3.x/installation-guide/upgrades/3.18.5/README.adoc
@@ -1,0 +1,13 @@
+= Upgrade to 3.18.5
+
+== Breaking changes
+
+=== Portal API
+
+Endpoint: `[GET] portal/environments/{envId}/applications`.
+
+For performance reasons, calling `/applications?size=-1` will no longer return the number of subscribers and the only information available in the owner of each application will be:
+
+- id
+- displayName
+- email


### PR DESCRIPTION
**Issue**

https://github.com/gravitee-io/issues/issues/7836

**Description**

Adding a breaking change information in APIM upgrade guide regarding the portal API.
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://graviteedocs.blob.core.windows.net/7836-apim-3-18-x-bc-portal-api/index.html)
<!-- UI placeholder end -->
