### PR TITLE
docs: APIM bridge gateway documentation improvement

### DIFF
--- a/pages/apim/3.x/installation-guide/hybrid/installation_guide_hybrid_deployment.adoc
+++ b/pages/apim/3.x/installation-guide/hybrid/installation_guide_hybrid_deployment.adoc
@@ -41,31 +41,22 @@ a new plugin.
 ==== Installation
 
 To expose the new HTTP API, you need to install a new plugin inside the `plugins` directory of APIM Gateway.
-This plugin can be found at https://download.gravitee.io/#graviteeio-apim/plugins/repositories/gravitee-apim-repository-gateway-bridge-http/
+This plugin can be found at https://download.gravitee.io/#graviteeio-apim/plugins/repositories/gravitee-apim-repository-gateway-bridge-http-server/
 
 NOTE: This plugin is disabled by default from APIM 3.13.0.
 
 [source,bash]
 ----
-$ wget -O ${GRAVITEEIO_HOME}/plugins https://download.gravitee.io/graviteeio-apim/plugins/repositories/gravitee-apim-repository-gateway-bridge-http/gravitee-apim-repository-gateway-bridge-http-server-${PLUGIN_VERSION}.zip
+$ wget -O ${GRAVITEEIO_HOME}/plugins https://download.gravitee.io/graviteeio-apim/plugins/repositories/gravitee-apim-repository-gateway-bridge-http-server/gravitee-apim-repository-gateway-bridge-http-server-${PLUGIN_VERSION}.zip
 ----
 
 [NOTE]
 ====
-You can remove some of the existing plugins available by default in APIM Gateway: the sync service,
-all the cache services, the policies and the resources.
+You can safely remove all plugins that start with the following names - these are not used on a bridge server gateway but are available by default in the APIM Gateway:
 
-For example, in APIM 1.18.0, the `plugins` directory contains the following files:
-
- gravitee-gateway-services-localregistry-1.18.0.zip
- gravitee-gateway-services-ratelimit-1.2.0.zip
- gravitee-gateway-services-monitoring-1.18.0.zip
- gravitee-gateway-services-node-healthcheck-1.18.0.zip
- gravitee-reporter-elasticsearch-1.18.0.zip
- gravitee-reporter-file-1.3.0.zip
- gravitee-repository-ehcache-1.0.0.zip
- gravitee-repository-gateway-bridge-http-server-1.0.0.zip
- gravitee-repository-mongodb-1.18.0.zip
+- gravitee-apim-gateway-services-sync*
+- gravitee-policy-*
+- gravitee-resource-*
 
 ====
 
@@ -123,11 +114,11 @@ You should receive a response containing an empty array or a list of APIs.
 
 To consume the HTTP bridge, you need to replace default repository plugins (usually a MongoDB repository) with
 a new HTTP repository in the APIM Gateway `plugins` directory.
-This plugin can be found at https://download.gravitee.io/#graviteeio-apim/plugins/repositories/gravitee-apim-repository-gateway-bridge-http/
+This plugin can be found at https://download.gravitee.io/#graviteeio-apim/plugins/repositories/gravitee-apim-repository-gateway-bridge-http-client/
 
 [source,bash]
 ----
-$ wget -O ${GRAVITEEIO_HOME}/plugins https://download.gravitee.io/graviteeio-apim/plugins/repositories/gravitee-apim-repository-gateway-bridge-http/gravitee-apim-repository-gateway-bridge-http-client-${PLUGIN_VERSION}.zip
+$ wget -O ${GRAVITEEIO_HOME}/plugins https://download.gravitee.io/graviteeio-apim/plugins/repositories/gravitee-apim-repository-gateway-bridge-http-client/gravitee-apim-repository-gateway-bridge-http-client-${PLUGIN_VERSION}.zip
 ----
 
 ==== Configuration


### PR DESCRIPTION
This fixes 2 broken links.
And rephrases the "remove useless plugin" part, which was really confusing : some users were removing the listed plugins but they have to be kept.
(And the APIM 1.18.0 example was outdated)
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://graviteedocs.blob.core.windows.net/docs-improvebridgedoc/index.html)
<!-- UI placeholder end -->
