### PR TITLE
add breaking change information about the return of a resource

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -120,9 +120,9 @@ products:
     _1x:
       version: 1.30.31
     _3x:
-      version: 3.18.0
+      version: 3.18.9
     ee:
-      version: 3.18.0
+      version: 3.18.9
   am:
     version: 3.18.4
     ee:

--- a/pages/apim/3.x/installation-guide/installation-guide-migration.adoc
+++ b/pages/apim/3.x/installation-guide/installation-guide-migration.adoc
@@ -13,6 +13,8 @@ You may be required to perform manual actions as part of the upgrade.
 WARNING: Be sure to run scripts on the correct database since `gravitee` is not always the default database!
 Check your db name by running `show dbs;`
 
+include::upgrades/3.18.9/README.adoc[leveloffset=+1]
+
 include::upgrades/3.18.7/README.adoc[leveloffset=+1]
 
 include::upgrades/3.18.5/README.adoc[leveloffset=+1]

--- a/pages/apim/3.x/installation-guide/upgrades/3.18.9/README.adoc
+++ b/pages/apim/3.x/installation-guide/upgrades/3.18.9/README.adoc
@@ -1,0 +1,10 @@
+= Upgrade to 3.18.9
+
+== Breaking changes
+
+=== Change of return type when calling /apis/{apiId}/subscribers
+
+To improve performance while fetching the subscribers of an API, internal methods have changed and the output has evolved.
+As a result, a call to  `/organizations/{orgId}/environments/{envId}/apis/{apiId}/subscribers` now returns a list of `ApplicationListItem` instead of `ApplicationEntity`.
+
+The `ApplicationListItem` class contains all the fields present in the `ApplicationEntity` class.


### PR DESCRIPTION
**Issue**

https://github.com/gravitee-io/issues/issues/8421

**Description**

add breaking change information about the return of `/apis/{apiId}/subscribers`
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://graviteedocs.blob.core.windows.net/8421-improve-api-subscriptions-page-loading/index.html)
<!-- UI placeholder end -->
