### PR TITLE
docs(apim): change changelogs location

### DIFF
--- a/pages/apim/1.x/changelog.adoc
+++ b/pages/apim/1.x/changelog.adoc
@@ -4,4 +4,4 @@
 :page-toc: false
 :page-layout: apim1x
 
-include::https://raw.githubusercontent.com/gravitee-io/issues/master/CHANGELOG.adoc[]
+include::https://raw.githubusercontent.com/gravitee-io/gravitee-api-management/master/release/changelog/CHANGELOG.adoc[]

--- a/pages/apim/3.x/changelog.adoc
+++ b/pages/apim/3.x/changelog.adoc
@@ -4,4 +4,4 @@
 :page-toc: false
 :page-layout: apim3x
 
-include::https://raw.githubusercontent.com/gravitee-io/issues/master/CHANGELOG-v3.adoc[]
+include::https://raw.githubusercontent.com/gravitee-io/gravitee-api-management/master/release/changelog/CHANGELOG-v3.adoc[]


### PR DESCRIPTION
**Issue**

https://github.com/gravitee-io/issues/issues/8186

**Description**

Following the changes on the changelog generation in the APIM project, here we change the APIM changelogs locations

**Screenshots**
No real visual impact here

<img width="1792" alt="Screenshot 2022-09-20 at 17 05 17" src="https://user-images.githubusercontent.com/25704259/191294525-ccb0f2da-24bb-47be-a8c9-b83ba25a3fb7.png">

<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://graviteedocs.blob.core.windows.net/docs-change-apim-changelog-location/index.html)
<!-- UI placeholder end -->
