### PR TITLE
fix: expose APIM 3.18.10 part in the migration guide

### DIFF
--- a/pages/apim/3.x/installation-guide/installation-guide-migration.adoc
+++ b/pages/apim/3.x/installation-guide/installation-guide-migration.adoc
@@ -13,6 +13,8 @@ You may be required to perform manual actions as part of the upgrade.
 WARNING: Be sure to run scripts on the correct database since `gravitee` is not always the default database!
 Check your db name by running `show dbs;`
 
+include::upgrades/3.18.10/README.adoc[leveloffset=+1]
+
 include::upgrades/3.18.9/README.adoc[leveloffset=+1]
 
 include::upgrades/3.18.7/README.adoc[leveloffset=+1]


### PR DESCRIPTION
**Issue**

N/A

**Description**

Just add the 3.18.10 inclusion in the migration guide. Otherwise, it won't be published.
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://graviteedocs.blob.core.windows.net/fix-apim-3-18-10-upgrade-guide/index.html)
<!-- UI placeholder end -->
