### PR TITLE
FIX hybrid install doc

### DIFF
--- a/pages/apim/3.x/installation-guide/hybrid/installation_guide_hybrid_deployment.adoc
+++ b/pages/apim/3.x/installation-guide/hybrid/installation_guide_hybrid_deployment.adoc
@@ -97,9 +97,9 @@ services:
           password:
 ----
 
-==== Check the APIM Gateway node is running
+==== Check the APIM Gateway (HTTP bridge server) node is running
 
-You can test that your APIM Gateway node is running by sending an HTTP request to port `8082` on `localhost`:
+You can test that your APIM Gateway (HTTP bridge server) node is running by sending an HTTP request to port `18092` on `localhost`:
 
 [source,bash]
 ----


### PR DESCRIPTION
Fix HTTP bridge server port

**Issue**

None

**Description**

Update (fix) hybrid install doc, wrong port
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://graviteedocs.blob.core.windows.net/fix-hybrid-install-doc/index.html)
<!-- UI placeholder end -->
