### PR TITLE
Add breaking change info about Console with a custom base url

### DIFF
--- a/pages/apim/3.x/installation-guide/upgrades/3.19.0/README.adoc
+++ b/pages/apim/3.x/installation-guide/upgrades/3.19.0/README.adoc
@@ -19,9 +19,11 @@ We recommend to update your dependency settings on `gravitee-gateway-api` to ver
 === Docker: Portal nginx configuration
 In order to provide a better security, the default nginx configuration of the portal docker image has been updated to add by default a Content-Security-Policies header for framing.
 After upgrading, the nginx configuration will be updated with this new line:
-```
+
+[source]
+----
 add_header Content-Security-Policy "frame-ancestors 'self';" always;
-```
+----
 But as APIM Portal is embedded in APIM Console for the theme customisation, this new header may block the portal from being displayed in the console.
 
 There are 2 ways to manage this change:
@@ -29,10 +31,105 @@ There are 2 ways to manage this change:
 1. *Not recommended*. You can disable this security header by setting the environment variable `FRAME_PROTECTION_ENABLED` to `false` when starting the docker container.
 2. You can configure the `frame-ancestors` directive to allow the console to display the portal. To do this set the environment variable `ALLOWED_FRAME_ANCESTOR_URLS` with the list of allowed URLs.
 For example:
-```
+
+[source]
+----
 ALLOWED_FRAME_ANCESTOR_URLS="https://mydomain.com https://mydomain2.com"
 ALLOWED_FRAME_ANCESTOR_URLS="https://mydomain.com 'self'"
 ALLOWED_FRAME_ANCESTOR_URLS="mydomain.com"
-```
+----
 
 See https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/frame-ancestors[here^] for more information about the Content-Security-Policy header.
+
+=== Console with a custom base url
+
+By default, the console and the portal are made to work at the root of a URL, for instance:
+
+- `https://apim.portal.com/...`
+- `https://apim.console-ui.com/...`
+
+So the assets (image and js files) are loaded from the root, for instance: `https://apim.portal.com/main.js`
+
+But, for different reasons such as DNS limitations, some users would like to use a single domain and share it for all APIM components. Something like:
+
+- `http://apim/portal`
+- `http://apim/console`
+
+In this case, both the portal and console applications need to know the `base_href` which allows them to properly load the different assets (`http://apim/portal/main.js`). This should work with whatever URL is used by the user to load the page: a complex link created during login, a redirection, a reload of a page, or just the base URL.
+
+⚠️ Previously the console application was magically working without custom configuration, it's not the case anymore.
+In order to handle these scenarios you have the following options:
+
+==== A - Using a reverse proxy
+
+Please refer to this section from the documentation:  https://docs.gravitee.io/apim/3.x/apim_how_to_configure_reverse_proxy.html#nginx_container
+
+This is working thanks to config which will replace the `base_href` with the right value:
+
+[source,nginx]
+----
+                sub_filter_once  on;
+                sub_filter  '<base href="/' '<base href="/console/';
+----
+
+==== B - Using environment variables with Gravitee.io APIM Docker images
+
+_Note_: This option is valid only if you're using the official Gravitee.io APIM Docker images.
+
+The portal and console docker images handle environment variables to configure the `base_href` of the apps:
+
+ - `PORTAL_BASE_HREF` for the Portal (it was already there in previous versions)
+ - `CONSOLE_BASE_HREF` for the Console (🆕 this one is new)
+
+This variable will change the `base_href` of the app using this kind of configuration:
+
+[source,nginx]
+----
+        sub_filter '<base href="/"' '<base href="{{ getenv "PORTAL_BASE_HREF" "/" }}"';
+----
+
+The full configuration is available here: https://github.com/gravitee-io/gravitee-api-management/blob/master/gravitee-apim-portal-webui/docker/config/templates/default.conf.tmpl
+
+
+You can find an example of use in a simple Docker Compose setup we have in the repository:
+https://github.com/gravitee-io/gravitee-api-management/tree/3.19.x/docker/quick-setup/nginx
+
+The magic is happening because of https://github.com/gravitee-io/gravitee-api-management/blob/b03a8eb705280e5f44d5a58293306d29838e79ee/docker/quick-setup/nginx/docker-compose.yml#L123:
+
+[source]
+----
+        CONSOLE_BASE_HREF=/console/
+----
+
+⚠️ The trailing `/` on the previous snippet is **MANDATORY**
+
+==== B (Bis) - Using environment variables with Helm Chart
+
+If the Helm charts are used in a way that each of the Portal, Console, Management-api and Gateway has its own domain then no specific configuration is needed.
+
+Otherwise, it will be needed to set the correct `PORTAL_BASE_HREF` and `CONSOLE_BASE_HREF` environment variables, as explained in section B.
+
+For instance:
+
+[source,yaml]
+----
+ui:
+  image:
+    repository: graviteeio/apim-management-ui
+    pullPolicy: IfNotPresent
+  ingress:
+    tls: false
+    hosts:
+      - localhost
+  baseURL: http://localhost:8081/management/organizations/DEFAULT/environments/DEFAULT/
+  env:
+    - name: CONSOLE_BASE_HREF
+      value: "/console/"
+...
+portal:
+  ...
+  env:
+    - name: PORTAL_BASE_HREF
+      value: "/portal/"
+----
+


### PR DESCRIPTION
**Issue**

NA

**Description**

Add breaking change info about the Console with a custom base URL

For extra details see https://github.com/gravitee-io/issues/issues/8518

<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://graviteedocs.blob.core.windows.net/add-missing-bc-in-3-19/index.html)
<!-- UI placeholder end -->
