### PR TITLE
docs: add basic information on new AE connector in 3.18.0

### DIFF
--- a/pages/ae/apim/apim-installation.adoc
+++ b/pages/ae/apim/apim-installation.adoc
@@ -19,6 +19,8 @@ be an link:{{ '/ee/ee_introduction.html' | relative_url }}[Enterprise version].
 
 == Installation
 
+NOTE: Starting from 3.18, the AE connector comes bundled with API Management, you don't need to download and install it.
+
 === Download connector
 
 [source,bash]

--- a/pages/ae/apim/apim-installation.adoc
+++ b/pages/ae/apim/apim-installation.adoc
@@ -19,7 +19,7 @@ be an link:{{ '/ee/ee_introduction.html' | relative_url }}[Enterprise version].
 
 == Installation
 
-NOTE: Starting from 3.18, the AE connector comes bundled with API Management, you don't need to download and install it.
+NOTE: From APIM version 3.18, you do not need to download and install the AE connector separately - it is shipped as part of the APIM bundle.
 
 === Download connector
 


### PR DESCRIPTION
**Issue**

https://graviteecommunity.atlassian.net/browse/APIM-168

**Description**

Add information block on the fact that since 3.18.0, a user does not have to download AlertEngine connector any more. It's embedded.
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://graviteedocs.blob.core.windows.net/add-information-about-alert-engine-connector/index.html)
<!-- UI placeholder end -->
