### PR TITLE
docs: include new AE release 1.6.6

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -128,7 +128,7 @@ products:
     ee:
       version: 3.19.0
   ae:
-    version: 1.6.1
+    version: 1.6.6
     name: Gravitee.io Alert Engine (AE)
 
 asciidoc: {}


### PR DESCRIPTION
**Issue**

N/A

**Description**

Add new Alert-Engine release 1.6.6

**Screenshots**

**Additional context**
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://graviteedocs.blob.core.windows.net/docs-release-ae-1-6-6/index.html)
<!-- UI placeholder end -->
