### PR TITLE
DOC-260 Added a version compatibility matrix for Control Plane and Gateway versions

### DIFF
--- a/pages/apim/3.x/installation-guide/hybrid/installation_guide_hybrid_deployment.adoc
+++ b/pages/apim/3.x/installation-guide/hybrid/installation_guide_hybrid_deployment.adoc
@@ -20,6 +20,17 @@ The following diagram shows a typical hybrid APIM architecture:
 .Deployment architecture
 image::{% link images/apim/3.x/installation/hybrid/hybrid_deployment_architecture.png %}[Hybrid deployment architecture]
 
+== Gateway / Control Plane version compatibility matrix
+
+The table below shows which Control Plane and Gateway versions are compatible based on the APIM version used:
+
+[width="100%",cols="30%,30%,30%",frame="topbot",options="header"]
+|======================
+|Component |Only identical CP & GW versions in range are compatible |Any CP & GW versions in range are compatible
+|Control Plane (CP) version |prior to 3.15.16 |from 3.15.16 to 3.19.1
+|Gateway (GW) version |prior to 3.15.16 |from 3.15.16 to 3.19.1
+|======================
+
 == Configuration
 
 For APIM Gateway to work in this setup, you need two components:

--- a/pages/apim/3.x/installation-guide/with-zip/installation-guide-gateway-install-zip.adoc
+++ b/pages/apim/3.x/installation-guide/with-zip/installation-guide-gateway-install-zip.adoc
@@ -30,6 +30,17 @@ reporting and analytics. See the vendor documentation for supported versions.
 NOTE: You can download MongoDB from https://www.mongodb.org/downloads#production[MongoDB Download Site, window=\"_blank\"]
 and Elasticsearch from https://www.elastic.co/downloads/elasticsearch[Elastic Download Site, window=\"_blank\"]
 
+=== Gateway / Control Plane version compatibility matrix
+
+The table below shows which Control Plane and Gateway versions are compatible based on the APIM version used:
+
+[width="100%",cols="30%,30%,30%",frame="topbot",options="header"]
+|======================
+|Component |Only identical CP & GW versions in range are compatible |Any CP & GW versions in range are compatible
+|Control Plane (CP) version |prior to 3.15.16 |from 3.15.16 to 3.19.1
+|Gateway (GW) version |prior to 3.15.16 |from 3.15.16 to 3.19.1
+|======================
+
 == Download and extract the `.zip` archive
 
 Note that the archive includes the binaries for all the APIM components, so if you previously downloaded it to install another component, you do not need to download it again.


### PR DESCRIPTION
DOC-260 Added a version compatibility matrix for Control Plane and Gateway versions

**Issue**

https://graviteedevops.atlassian.net/browse/DOC-260

**Description**

DOC-260 Added a version compatibility matrix for Control Plane and Gateway versions
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://graviteedocs.blob.core.windows.net/doc-260/index.html)
<!-- UI placeholder end -->
