### PR TITLE
docs: bump AE latest version to 1.6.7

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -128,7 +128,7 @@ products:
     ee:
       version: 3.19.2
   ae:
-    version: 1.6.6
+    version: 1.6.7
     name: Gravitee.io Alert Engine (AE)
 
 asciidoc: {}


### PR DESCRIPTION
**Description**

Bump latest version of AE to 1.6.7
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://graviteedocs.blob.core.windows.net/ae-1-6-7/index.html)
<!-- UI placeholder end -->
