### PR TITLE
[APIM] Add changelog for new 3.19.x release

### DIFF
--- a/_data/sidebars/apim_3_x_sidebar.yml
+++ b/_data/sidebars/apim_3_x_sidebar.yml
@@ -1,5 +1,3 @@
-# This is your sidebar TOC. The sidebar code loops through sections here and provides the appropriate formatting.
-
 entries:
   - title: Sidebar
     product: API Management
@@ -21,7 +19,6 @@ entries:
           - title: Plugins
             output: web
             url: /apim/3.x/apim_overview_plugins.html
-
       - title: Installation Guide
         output: web
         folderitems:
@@ -152,7 +149,6 @@ entries:
           - title: Upgrade Guide
             output: web
             url: /apim/3.x/apim_installguide_migration.html
-
       - title: Quick Start Guide
         output: web
         folderitems:
@@ -190,119 +186,118 @@ entries:
                   - title: Test the API
                     output: web
                     url: /apim/3.x/apim_quickstart_consume_test.html
-
       - title: Configuration Guide
         output: web
         folderitems:
-         - title: Introduction
-           output: web
-           url: /apim/3.x/apim_configurationguide.html
-           subfolders:
-            - title: Configure APIM Gateway
-              output: web
-              subfolderitems:
-               - title: General Configuration
-                 output: web
-                 url: /apim/3.x/apim_installguide_gateway_configuration.html
-               - title: Internal API
-                 output: web
-                 url: /apim/3.x/apim_installguide_gateway_technical_api.html
-               - title: Metrics
-                 output: web
-                 url: /apim/3.x/apim_installguide_gateway_metrics.html
-               - title: Enable OpenTracing
-                 output: web
-                 url: /apim/3.x/apim_enable_opentracing_with_jaeger.html
-               - title: OpenTracing in Docker
-                 output: web
-                 url: /apim/3.x/apim_opentracing_in_docker.html
-            - title: Configure APIM API
-              output: web
-              subfolderitems:
-               - title: General Configuration
-                 output: web
-                 url: /apim/3.x/apim_installguide_rest_apis_configuration.html
-               - title: Internal API
-                 output: web
-                 url: /apim/3.x/apim_installguide_rest_apis_technical_api.html
-               - title: Metrics
-                 output: web
-                 url: /apim/3.x/apim_installguide_rest_apis_metrics.html
-               - title: Security
-                 output: web
-                 url: /apim/3.x/apim_installguide_rest_apis_security.html
-            - title: Configure APIM Console
-              output: web
-              subfolderitems:
-               - title: General Configuration
-                 output: web
-                 url: /apim/3.x/apim_installguide_management_ui_configuration.html
-               - title: Dashboards
-                 output: web
-                 url: /apim/3.x/apim_installguide_dashboard_configuration.html
-            - title: Configure APIM Portal
-              output: web
-              subfolderitems:
-               - title: General Configuration
-                 output: web
-                 url: /apim/3.x/apim_installguide_portal_ui_configuration.html
-            - title: Configure Repositories
-              output: web
-              subfolderitems:
-               - title: Introduction
-                 output: web
-                 url: /apim/3.x/apim_installguide_repositories.html
-               - title: Elasticsearch
-                 output: web
-                 url: /apim/3.x/apim_installguide_repositories_elasticsearch.html
-               - title: MongoDB
-                 output: web
-                 url: /apim/3.x/apim_installguide_repositories_mongodb.html
-               - title: JDBC
-                 output: web
-                 url: /apim/3.x/apim_installguide_repositories_jdbc.html
-               - title: Redis
-                 output: web
-                 url: /apim/3.x/apim_installguide_repositories_redis.html
-            - title: Configure Authentication
-              output: web
-              subfolderitems:
-               - title: Introduction
-                 output: web
-                 url: /apim/3.x/apim_installguide_authentication.html
-               - title: Connect with In-Memory Users
-                 output: web
-                 url: /apim/3.x/apim_installguide_authentication_inmemory.html
-               - title: Connect with LDAP/Active Directory
-                 output: web
-                 url: /apim/3.x/apim_installguide_authentication_ldap.html
-               - title: Connect with APIM Repository
-                 output: web
-                 url: /apim/3.x/apim_installguide_authentication_apim.html
-               - title: Connect with Gravitee.io Access Management
-                 output: web
-                 url: /apim/3.x/apim_installguide_authentication_graviteeam.html
-               - title: Connect with GitHub
-                 output: web
-                 url: /apim/3.x/apim_installguide_authentication_github.html
-               - title: Connect with Google
-                 output: web
-                 url: /apim/3.x/apim_installguide_authentication_google.html
-               - title: Connect with Keycloak
-                 output: web
-                 url: /apim/3.x/apim_installguide_authentication_keycloak.html
-         - title: Configure Reporters
-           output: web
-           url: /apim/3.x/apim_installguide_reporters.html
-         - title: Configure Cache
-           output: web
-           url: /apim/3.x/apim_installguide_cache.html
-         - title: Configure Notifications
-           output: web
-           url: /apim/3.x/apim_installguide_configuration_notifications.html
-         - title: Configure Dictionaries
-           output: web
-           url: /apim/3.x/apim_installguide_configuration_dictionaries.html
+          - title: Introduction
+            output: web
+            url: /apim/3.x/apim_configurationguide.html
+            subfolders:
+              - title: Configure APIM Gateway
+                output: web
+                subfolderitems:
+                  - title: General Configuration
+                    output: web
+                    url: /apim/3.x/apim_installguide_gateway_configuration.html
+                  - title: Internal API
+                    output: web
+                    url: /apim/3.x/apim_installguide_gateway_technical_api.html
+                  - title: Metrics
+                    output: web
+                    url: /apim/3.x/apim_installguide_gateway_metrics.html
+                  - title: Enable OpenTracing
+                    output: web
+                    url: /apim/3.x/apim_enable_opentracing_with_jaeger.html
+                  - title: OpenTracing in Docker
+                    output: web
+                    url: /apim/3.x/apim_opentracing_in_docker.html
+              - title: Configure APIM API
+                output: web
+                subfolderitems:
+                  - title: General Configuration
+                    output: web
+                    url: /apim/3.x/apim_installguide_rest_apis_configuration.html
+                  - title: Internal API
+                    output: web
+                    url: /apim/3.x/apim_installguide_rest_apis_technical_api.html
+                  - title: Metrics
+                    output: web
+                    url: /apim/3.x/apim_installguide_rest_apis_metrics.html
+                  - title: Security
+                    output: web
+                    url: /apim/3.x/apim_installguide_rest_apis_security.html
+              - title: Configure APIM Console
+                output: web
+                subfolderitems:
+                  - title: General Configuration
+                    output: web
+                    url: /apim/3.x/apim_installguide_management_ui_configuration.html
+                  - title: Dashboards
+                    output: web
+                    url: /apim/3.x/apim_installguide_dashboard_configuration.html
+              - title: Configure APIM Portal
+                output: web
+                subfolderitems:
+                  - title: General Configuration
+                    output: web
+                    url: /apim/3.x/apim_installguide_portal_ui_configuration.html
+              - title: Configure Repositories
+                output: web
+                subfolderitems:
+                  - title: Introduction
+                    output: web
+                    url: /apim/3.x/apim_installguide_repositories.html
+                  - title: Elasticsearch
+                    output: web
+                    url: /apim/3.x/apim_installguide_repositories_elasticsearch.html
+                  - title: MongoDB
+                    output: web
+                    url: /apim/3.x/apim_installguide_repositories_mongodb.html
+                  - title: JDBC
+                    output: web
+                    url: /apim/3.x/apim_installguide_repositories_jdbc.html
+                  - title: Redis
+                    output: web
+                    url: /apim/3.x/apim_installguide_repositories_redis.html
+              - title: Configure Authentication
+                output: web
+                subfolderitems:
+                  - title: Introduction
+                    output: web
+                    url: /apim/3.x/apim_installguide_authentication.html
+                  - title: Connect with In-Memory Users
+                    output: web
+                    url: /apim/3.x/apim_installguide_authentication_inmemory.html
+                  - title: Connect with LDAP/Active Directory
+                    output: web
+                    url: /apim/3.x/apim_installguide_authentication_ldap.html
+                  - title: Connect with APIM Repository
+                    output: web
+                    url: /apim/3.x/apim_installguide_authentication_apim.html
+                  - title: Connect with Gravitee.io Access Management
+                    output: web
+                    url: /apim/3.x/apim_installguide_authentication_graviteeam.html
+                  - title: Connect with GitHub
+                    output: web
+                    url: /apim/3.x/apim_installguide_authentication_github.html
+                  - title: Connect with Google
+                    output: web
+                    url: /apim/3.x/apim_installguide_authentication_google.html
+                  - title: Connect with Keycloak
+                    output: web
+                    url: /apim/3.x/apim_installguide_authentication_keycloak.html
+          - title: Configure Reporters
+            output: web
+            url: /apim/3.x/apim_installguide_reporters.html
+          - title: Configure Cache
+            output: web
+            url: /apim/3.x/apim_installguide_cache.html
+          - title: Configure Notifications
+            output: web
+            url: /apim/3.x/apim_installguide_configuration_notifications.html
+          - title: Configure Dictionaries
+            output: web
+            url: /apim/3.x/apim_installguide_configuration_dictionaries.html
       - title: API Publisher Guide
         output: web
         folderitems:
@@ -395,39 +390,39 @@ entries:
               - title: Resources
                 output: web
                 subfolderitems:
-                - title: Introduction
-                  output: web
-                  url: /apim/3.x/apim_resources_overview.html
-                - title: Cache
-                  output: web
-                  url: /apim/3.x/apim_resources_cache.html
-                - title: Cache Redis
-                  output: web
-                  url: /apim/3.x/apim_resources_cache_redis.html
-                - title: OAuth2 - Gravitee.io Access Management
-                  output: web
-                  url: /apim/3.x/apim_resources_oauth2_am.html
-                - title: OAuth2 - Generic Authorization Server
-                  output: web
-                  url: /apim/3.x/apim_resources_oauth2_generic.html
+                  - title: Introduction
+                    output: web
+                    url: /apim/3.x/apim_resources_overview.html
+                  - title: Cache
+                    output: web
+                    url: /apim/3.x/apim_resources_cache.html
+                  - title: Cache Redis
+                    output: web
+                    url: /apim/3.x/apim_resources_cache_redis.html
+                  - title: OAuth2 - Gravitee.io Access Management
+                    output: web
+                    url: /apim/3.x/apim_resources_oauth2_am.html
+                  - title: OAuth2 - Generic Authorization Server
+                    output: web
+                    url: /apim/3.x/apim_resources_oauth2_generic.html
               - title: Design Studio Guide
                 output: web
                 subfolderitems:
-                - title: Introduction
-                  output: web
-                  url: /apim/3.x/apim_publisherguide_design_studio_overview.html
-                - title: Migrate to Design Studio
-                  output: web
-                  url: /apim/3.x/apim_publisherguide_design_studio_migrate.html
-                - title: Design Your API Flows
-                  output: web
-                  url: /apim/3.x/apim_publisherguide_design_studio_create.html
-                - title: Try it! Mode
-                  output: web
-                  url: /apim/3.x/apim_publisherguide_design_studio_try_it.html
-                - title: Debug Mode
-                  output: web
-                  url: /apim/3.x/apim_publisherguide_design_studio_debug_mode.html
+                  - title: Introduction
+                    output: web
+                    url: /apim/3.x/apim_publisherguide_design_studio_overview.html
+                  - title: Migrate to Design Studio
+                    output: web
+                    url: /apim/3.x/apim_publisherguide_design_studio_migrate.html
+                  - title: Design Your API Flows
+                    output: web
+                    url: /apim/3.x/apim_publisherguide_design_studio_create.html
+                  - title: Try it! Mode
+                    output: web
+                    url: /apim/3.x/apim_publisherguide_design_studio_try_it.html
+                  - title: Debug Mode
+                    output: web
+                    url: /apim/3.x/apim_publisherguide_design_studio_debug_mode.html
               - title: Documentation
                 output: web
                 subfolderitems:
@@ -470,23 +465,21 @@ entries:
           - title: Expression Language
             output: web
             url: /apim/3.x/apim_publisherguide_expression_language.html
-
       - title: API Consumer Guide
         output: web
         folderitems:
-         - title: Introduction
-           output: web
-           url: /apim/3.x/apim_consumerguide_portal.html
-         - title: Create an Account
-           output: web
-           url: /apim/3.x/apim_consumerguide_create_account.html
-         - title: Manage Applications
-           output: web
-           url: /apim/3.x/apim_consumerguide_manage_applications.html
-         - title: Subscribe to APIs
-           output: web
-           url: /apim/3.x/apim_consumerguide_subscribe.html
-
+          - title: Introduction
+            output: web
+            url: /apim/3.x/apim_consumerguide_portal.html
+          - title: Create an Account
+            output: web
+            url: /apim/3.x/apim_consumerguide_create_account.html
+          - title: Manage Applications
+            output: web
+            url: /apim/3.x/apim_consumerguide_manage_applications.html
+          - title: Subscribe to APIs
+            output: web
+            url: /apim/3.x/apim_consumerguide_subscribe.html
       - title: Administration Guide
         output: web
         folderitems:
@@ -506,7 +499,6 @@ entries:
           - title: Platform policies
             output: web
             url: /apim/3.x/apim_adminguide_platform_policies.html
-
       - title: How To
         output: web
         folderitems:
@@ -528,7 +520,6 @@ entries:
           - title: Policies
             output: web
             url: /apim/3.x/apim_devguide_policies.html
-
       - title: Policy Reference
         output: web
         folderitems:
@@ -676,8 +667,6 @@ entries:
           - title: XSLT
             output: web
             url: /apim/3.x/apim_policies_xslt.html
-
-
       - title: Kubernetes Operator [BETA]
         output: web
         folderitems:
@@ -733,17 +722,18 @@ entries:
           - title: GKO changelog
             output: web
             url: apim/3.x/apim_kubernetes_operator_changelog.html
-
       - title: API Reference
         output: web
         folderitems:
           - title: API Reference
             output: web
             url: /apim/3.x/apim_installguide_rest_apis_documentation.html
-
       - title: Changelog
         output: web
         folderitems:
           - title: Changelog
             output: web
             url: /apim/3.x/apim_changelog.html
+          - title: Changelog 3.19.x
+            output: web
+            url: /apim/3.x/changelog-3.19.html

--- a/pages/apim/3.x/changelog/changelog-3.19.adoc
+++ b/pages/apim/3.x/changelog/changelog-3.19.adoc
@@ -1,0 +1,11 @@
+:page-sidebar: apim_3_x_sidebar
+:page-permalink: apim/3.x/changelog-3.19.html
+:page-folder: apim
+:page-toc: false
+:page-layout: apim3x
+
+== APIM - 3.19.x (2022-11-30)
+
+=== Bug fixes
+
+=== Improvements


### PR DESCRIPTION

# New APIM version 3.19.x has been released
📝 You can modify the changelog template online [here](https://github.com/gravitee-io/gravitee-docs/edit/release-3.19.x/pages/apim/3.x/changelog/changelog-3.19.adoc)

Here is some information to help with the writing: 

## Commit messages 
<details>
  <summary>See all feats commit</summary>

0a32590373 feat(ui): add Content Security Policies in default nginx configuration for console and portal
a01d25b17c feat: move SSE entrypoint to its own repository
409549f40b feat: package endpoints & entrypoints
5b11c19939 feat: improve message structure
ceefe0097b feat: improve execution context structure
8fca76cbdd feat: turn V4 EndpointGroup configuration to a json object
28d9501b81 feat: replace old api list page with the new one
5849aee4e8 feat: improve authentication workflow of subscription based plans
a8fd2b5751 feat: add origin in search engine
7e7838fa84 feat: display kubernes icon for gko apis
b221eb5a01 feat: list apis with origin
b57b25e822 feat: add loading state in table
19eeda0a35 feat: adapt search bar size
a60a734206 feat: add edit action
703c7cb6a1 feat: use search engine
417d3c847b feat: add visibility column
da32f87de5 feat: add quality score column
ae46033028 feat: add out of sync icon
132a8af0ce feat: add api icons
cd36215fb6 feat: add columns
27a2119a77 feat: add filters on apis list page
ab50f45269 feat(entrypoint): add a new http-post entrypoint
389602544f feat(message): access body from VertxMessageServerRequest
97a8214c43 feat(mock-endpoint): log incoming message content
8983c95db8 feat(kafka): add kafka endpoint
3a3f949e7c feat(console): fetch paged apis
96920e77c3 feat(console): inity empty apis table
d405d7365b feat(console): add new apis
2ec68a6d89 feat(console): init api list screen migration
f17fcc5859 feat(perf): add keyless api scenario
06b6631b25 feat: delete api with kubernetes origin
5e7ccf9517 feat: gateway testing sdk inject vertx HttpClient HttpClient is more flexible to handle async calls, so we are able to do assertions on chunks. WebClient is limited because he only returns the response as a Single gravitee-io/issues#8286
0a40471c08 feat: gateway testing sdk api V4 deployment
790bcf95e2 feat: add endpoint registration in gateway testing sdk
5a6141976f feat: add entrypoint registration in gateway testing sdk
e46609d72d feat(rest-api): close each plans when delete api from K8s Origin
a64da8e55e feat: handle endpoint inherited configuration
5f4c7e80b7 feat: add default values for mocl endpoint configuration
067d4d128e feat: add messages count configuration in mock endpoint
48a56c0281 feat: implement endpoint invoker and resolver
9e82573515 feat: validate jupiter connector plugins configurations
69ee6a7f46 feat: use milliseconds and singular in mock endpoint configuration
5e2ee1cc7a feat: add EndpointInvoker and EndpointResolver
25b8fd4dba feat: add endpoint plugin module, with mock endpoint
5925a73905 feat: refactor the plan selection workflow
0340bda588 feat(rest-api): allow gko to start & stop api without publish event
f1ec25615c feat(gateway): handle v4 api deployment
48511bbd2d feat(entrypoint): add entrypoint plugin framework
6fd330abd9 feat(definition): Allow to CRUD AsyncAPI
49cbee24fd feat: deploy organization feature in gateway testing sdk gravitee-io/issues#8184
70fc957224 feat(definition): Allow to CRUD AsyncAPI
2f515b9677 feat: handle reactive timeout gravitee-io/issues#7988
04d7d51bca feat(kubernetes): support api managed from k8s
0b28dcdf2f feat(jupiter): websocket support
e00eb1e8b3 feat(jupiter): implement api logging support for jupiter
f2688fbc31 feat: handle apiKey and subscriptions with dedicated services instead of repositoryWrappers
86c97b1f27 feat(jupiter): implementation of debug mode
049093df48 feat(jupiter): reactive expression language evaluation


</details>

<details>
  <summary>See all fixs commit</summary>

d933671f67 fix: check subscriptions ids before evict
9170df7cfa fix: disable DOCTYPE usage for wsdl imports
3f19a9648b fix: handle huge payload from cockpit controller
afe625c858 fix(search): exclude V4 apis from search result
29fb8b628c fix(gateway): make API v1 paths based with API key plan work
45f609189e fix: bump expression-language dependency fixes nested expressions
a1c2013fe8 fix(test-sdk): restore the entrypoints registration
eedf4c353a fix: fix typo and unit tests
942f6bf031 fix(typo): update-api-case
d53ab9f334 fix: apikey plan selection jupiter mode
f5702f6a55 fix: add an index to improve apikeys sync [skip ci]
5fde6825ea fix: multi oauth plan selection
1a00919767 fix: apikey plan selection
566ba159be fix: pom.xml to reduce vulnerabilities
dd3ad38c89 fix: improve VersionUtils to be able to parse non stable versions
c7dc4da3b2 fix: bump expression-language to version 1.11.2 includes bugfixes from 1.9.x
7525abbc8a fix: fix HeartbeatService by removing Event state at the correct place
8cc0182fb5 fix: plan selection for v3 engine
3d157cc8ae fix: pom.xml to reduce vulnerabilities
8a118f6d59 fix(ci): use the version with modifier to change build.json files and for the tag
13bce80a67 fix: try to fix hearbeatservice like in 3.10.x
6432bc77d9 fix: make gateway apply request timeout properly
4e420689db fix(kafka): fix classloading while dealing with kafka objects
389c362866 fix: bump `gravitee-connector-api` to `1.1.4`
7cdc0dff44 fix: bump `gravitee-connector-http` to `2.0.5`
fa8678d7d2 fix: fix 3.18.7 merge
7488b9b335 fix(deps): update @toast-ui/editor to v2.5.4
515c9b545f fix(deps): update @gravitee/ui-components to v3.36.2
1bc0b0ae6c fix(): rename model class where prefix should be the specialization
6253a37f25 fix(deps): update @gravitee/ui-analytics to v3.6.0
3935783405 fix(e2e): ignore message with retry element
d2f5ea1f75 fix: pom.xml to reduce vulnerabilities
1e4c08ceae fix: keep JDK 11 for community build
bd0a6f5d19 fix: use the right EntrypointResource path variable name
1bd74bcd8d fix: add support failover for jupiter
987b0bfa41 fix: fix bump to new version of gateway-api
761eb77fec fix(rest-api): keep api created definition context
12c58b828e fix(gateway): fix flaky NullPointerException when k8s sync handleConfigMapEvent
d5c5860479 fix: e2e v1 definition
6c0da7e63d fix(rest): use new path service validation in both v2/v4 in order to check either virtualhost or path
53b45d8e30 fix(jdbc): escape a mysql/mariadb reserved word
6591c814fe fix: http request timeout refine default value assignation gravitee-io/issues#8273
87b57923fd fix: fix typo in response template config
28b242c578 fix(rest-api): use snake_case everywhere for definition_context property
d1f1c860f4 fix(gateway): disable `services.sync.kubernetes.enabled` by default
338414f015 fix: add planId in subscription cache key
f8813883b1 fix: return completable when no key for ResponseTemplateBasedFailureProcessor
abdb92a4b7 fix(gko): do not write config map env twice
7526c6d94f fix: set definition context on import
d37ef93719 fix: format liquibase change set
966668eba1 fix: use a correct api definition and fix the test accordingly
cfb5ad28c5 fix: return null instead of empty list when getting an undefined header
63d54ecd38 fix(e2e): use good WIREMOCK_BASE_URL
f9a5fa2d2d fix: migration sdk keyless policy to jupiter
fd3c465ccb fix: use reason from invoker when handling response gravitee-io/issues#7993
ecbede8b05 fix(build): allow to use SNAPSHOT version of parent-pom for the build
ff69fc3ae9 fix: gravitee-apim-console-webui/package.json & gravitee-apim-console-webui/package-lock.json to reduce vulnerabilities
4617950764 fix: avoid NPE when trying to notify on an API deployment
c42579595c fix(e2e): flaky tests
eb55419846 fix: run search index upgrader with admin role
7025cb5eb1 fix(e2e): give elastic more time to index 🤹 🤷‍♂️
5d73e2a51c fix(e2e): fix flaky e2e due to non waiting redeployment
5038460478 fix(e2e): set api crossId to update plan by import
b6c9a94948 fix(jupiter): wait for pending requests before stoping reactor
0306db17db fix(gateway): use new DebugApiReactorHandlerFactory next to rewording
7f61010ee3 fix(e2e): fix tsc errors
0b1fa42569 fix: missing application in refreshed subscription
bb6946d774 fix(deps): update @gravitee/ui-components to v3.36.1
13e1735ccc fix: use latest release version of gateway api
8d43ea0c8e fix(e2e): set wiremock `global-response-templating` option
9b87ec29bd fix: gravitee-apim-repository/gravitee-apim-repository-mongodb/pom.xml to reduce vulnerabilities
301ce0e41b fix: compute total nb of apis while listing categories for settings page only

</details>

## Jira issues

[See all Jira issues for 3.19.x version](https://gravitee.atlassian.net/jira/software/c/projects/APIM/issues/?jql=project%20%3D%20%22APIM%22%20and%20fixVersion%20%3D%203.19.x%20and%20status%20%3D%20Done%20ORDER%20BY%20created%20DESC)
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://graviteedocs.blob.core.windows.net/release-3-19-x/index.html)
<!-- UI placeholder end -->
