### PR TITLE
DOC-287 Fixed some bad links and updated Redis Cache Resource page

### DIFF
--- a/pages/apim/3.x/installation-guide/configuration/installation-guide-cache.adoc
+++ b/pages/apim/3.x/installation-guide/configuration/installation-guide-cache.adoc
@@ -98,4 +98,4 @@ Configuration of cache resources cannot be managed using the `hazelcast.xml` fil
 === Need a persistent cache ?
 
 Since 3.10, we provide a new link:{{ '/apim/3.x/apim_resources_cache_redis.html' | relative_url }}[Gravitee Resource Cache Redis] based on https://redis.io/documentation[Redis].
-This plugin is not in distribution by default, but you can https://download.gravitee.io/#graviteeio-apim/plugins/resources/gravitee-resource-cache-redis/[download] plugin and follow link:{{ '/apim/3.x/apim_installguide_docker_customize.html#install_an_additional_plugin' | relative_url }}[instructions] to install it.
+This plugin is not in distribution by default, but you can https://download.gravitee.io/#graviteeio-apim/plugins/resources/gravitee-resource-cache-redis/[download] plugin and follow link:{{ '/apim/3.x/apim_installation_guide_docker_customize.html#install_an_additional_plugin' | relative_url }}[instructions] to install it.

--- a/pages/apim/3.x/installation-guide/configuration/installation-guide-cache.adoc
+++ b/pages/apim/3.x/installation-guide/configuration/installation-guide-cache.adoc
@@ -98,4 +98,4 @@ Configuration of cache resources cannot be managed using the `hazelcast.xml` fil
 === Need a persistent cache ?
 
 Since 3.10, we provide a new link:{{ '/apim/3.x/apim_resources_cache_redis.html' | relative_url }}[Gravitee Resource Cache Redis] based on https://redis.io/documentation[Redis].
-This plugin is not in distribution by default, but you can https://download.gravitee.io/#graviteeio-apim/plugins/resources/gravitee-resource-cache-redis/[download] plugin and follow link:{{ '/apim/3.x/apim_installation_guide_docker_customize.html#install_an_additional_plugin' | relative_url }}[instructions] to install it.
+This plugin is not in distribution by default, but you can https://download.gravitee.io/#graviteeio-apim/plugins/resources/gravitee-resource-cache-redis/[download] the plugin and follow the link:{{ '/apim/3.x/apim_installation_guide_docker_customize.html#install_an_additional_plugin' | relative_url }}[instructions] to install it.

--- a/pages/apim/3.x/user-guide/publisher/resources/resource-cache-redis.adoc
+++ b/pages/apim/3.x/user-guide/publisher/resources/resource-cache-redis.adoc
@@ -3,6 +3,6 @@
 :page-folder: apim/user-guide/publisher/resources
 :page-layout: apim3x
 
-WARNING: This plugin is not in distribution by default, but you can https://download.gravitee.io/#graviteeio-apim/plugins/resources/gravitee-resource-cache-redis/[download] plugin and follow link:{{ '/apim/3.x/apim_installation_guide_docker_customize.html#install_an_additional_plugin' | relative_url }}[instructions] to install it. For more information on configuring cache in APIM, see link:{{ '/apim/3.x/apim_installguide_cache.html' | relative_url }}[Configure cache]. For information on configuring the Rate Limit repository plugin for Redis, see link:{{ '/apim/3.x/apim_installguide_repositories_redis.html' | relative_url }}[Configure cache].
+WARNING: This plugin is not in distribution by default, but you can https://download.gravitee.io/#graviteeio-apim/plugins/resources/gravitee-resource-cache-redis/[download the plugin] and follow link:{{ '/apim/3.x/apim_installation_guide_docker_customize.html#install_an_additional_plugin' | relative_url }}[instructions] to install it. For more information on configuring cache in APIM, see link:{{ '/apim/3.x/apim_installguide_cache.html' | relative_url }}[Configure cache]. For information on configuring the Rate Limit repository plugin for Redis, see link:{{ '/apim/3.x/apim_installguide_repositories_redis.html' | relative_url }}[Configure cache].
 
 include::https://raw.githubusercontent.com/gravitee-io/gravitee-resource-cache-redis/master/README.adoc[]

--- a/pages/apim/3.x/user-guide/publisher/resources/resource-cache-redis.adoc
+++ b/pages/apim/3.x/user-guide/publisher/resources/resource-cache-redis.adoc
@@ -3,6 +3,6 @@
 :page-folder: apim/user-guide/publisher/resources
 :page-layout: apim3x
 
-WARNING: This plugin is not in distribution by default, but you can https://download.gravitee.io/#graviteeio-apim/plugins/resources/gravitee-resource-cache-redis/[download the plugin] and follow link:{{ '/apim/3.x/apim_installation_guide_docker_customize.html#install_an_additional_plugin' | relative_url }}[instructions] to install it. For more information on configuring cache in APIM, see link:{{ '/apim/3.x/apim_installguide_cache.html' | relative_url }}[Configure cache]. For information on configuring the Rate Limit repository plugin for Redis, see link:{{ '/apim/3.x/apim_installguide_repositories_redis.html' | relative_url }}[Configure cache].
+WARNING: This plugin is not in distribution by default, but you can https://download.gravitee.io/#graviteeio-apim/plugins/resources/gravitee-resource-cache-redis/[download the plugin] and follow link:{{ '/apim/3.x/apim_installation_guide_docker_customize.html#install_an_additional_plugin' | relative_url }}[instructions] to install it. For more information on configuring cache in APIM, see link:{{ '/apim/3.x/apim_installguide_cache.html' | relative_url }}[Configure cache]. For information on configuring the Rate Limit repository plugin for Redis, see the link:{{ '/apim/3.x/apim_installguide_repositories_redis.html' | relative_url }}[Redis] page.
 
 include::https://raw.githubusercontent.com/gravitee-io/gravitee-resource-cache-redis/master/README.adoc[]

--- a/pages/apim/3.x/user-guide/publisher/resources/resource-cache-redis.adoc
+++ b/pages/apim/3.x/user-guide/publisher/resources/resource-cache-redis.adoc
@@ -3,6 +3,6 @@
 :page-folder: apim/user-guide/publisher/resources
 :page-layout: apim3x
 
-WARNING: This plugin is not in distribution by default, but you can https://download.gravitee.io/#graviteeio-apim/plugins/resources/gravitee-resource-cache-redis/[download] plugin and follow link:{{ '/apim/3.x/apim_installguide_docker_customize.html#install_an_additional_plugin' | relative_url }}[instructions] to install it.
+WARNING: This plugin is not in distribution by default, but you can https://download.gravitee.io/#graviteeio-apim/plugins/resources/gravitee-resource-cache-redis/[download] plugin and follow link:{{ '/apim/3.x/apim_installation_guide_docker_customize.html#install_an_additional_plugin' | relative_url }}[instructions] to install it. For more information on configuring cache in APIM, see link:{{ '/apim/3.x/apim_installguide_cache.html' | relative_url }}[Configure cache]. For information on configuring the Rate Limit repository plugin for Redis, see link:{{ '/apim/3.x/apim_installguide_repositories_redis.html' | relative_url }}[Configure cache].
 
 include::https://raw.githubusercontent.com/gravitee-io/gravitee-resource-cache-redis/master/README.adoc[]

--- a/pages/apim/3.x/user-guide/publisher/resources/resource-cache-redis.adoc
+++ b/pages/apim/3.x/user-guide/publisher/resources/resource-cache-redis.adoc
@@ -3,6 +3,6 @@
 :page-folder: apim/user-guide/publisher/resources
 :page-layout: apim3x
 
-WARNING: This plugin is not in distribution by default, but you can https://download.gravitee.io/#graviteeio-apim/plugins/resources/gravitee-resource-cache-redis/[download the plugin] and follow link:{{ '/apim/3.x/apim_installation_guide_docker_customize.html#install_an_additional_plugin' | relative_url }}[instructions] to install it. For more information on configuring cache in APIM, see link:{{ '/apim/3.x/apim_installguide_cache.html' | relative_url }}[Configure cache]. For information on configuring the Rate Limit repository plugin for Redis, see the link:{{ '/apim/3.x/apim_installguide_repositories_redis.html' | relative_url }}[Redis] page.
+WARNING: This plugin is not in distribution by default, but you can https://download.gravitee.io/#graviteeio-apim/plugins/resources/gravitee-resource-cache-redis/[download the plugin] and follow the link:{{ '/apim/3.x/apim_installation_guide_docker_customize.html#install_an_additional_plugin' | relative_url }}[instructions] to install it. For more information on configuring cache in APIM, see link:{{ '/apim/3.x/apim_installguide_cache.html' | relative_url }}[Configure cache]. For information on configuring the Rate Limit repository plugin for Redis, see the link:{{ '/apim/3.x/apim_installguide_repositories_redis.html' | relative_url }}[Redis] page.
 
 include::https://raw.githubusercontent.com/gravitee-io/gravitee-resource-cache-redis/master/README.adoc[]


### PR DESCRIPTION
DOC-287 Fixed some bad links and updated Redis Cache Resource page in the publisher guide with more relevant links

**Issue**

https://graviteedevops.atlassian.net/browse/DOC-287

**Description**

DOC-287 Fixed some bad links and updated Redis Cache Resource page in the publisher guide with more relevant links
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://graviteedocs.blob.core.windows.net/doc-287/index.html)
<!-- UI placeholder end -->
