### PR TITLE
docs(apim): correct gko management context example

### DIFF
--- a/pages/apim/3.x/kubernetes/apim-kubernetes-operator-user-guide-management-context.adoc
+++ b/pages/apim/3.x/kubernetes/apim-kubernetes-operator-user-guide-management-context.adoc
@@ -68,7 +68,7 @@ spec:
   environmentId: dev
   organizationId: acme
   auth:
-    auth:
+    credentials:
       username: admin
       password: admin
 ----


### PR DESCRIPTION
**Description**

The current Gravitee Kubernetes Operator management context example is wrong. The auth object contains a `credentials` attribute and not another `auth`
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://graviteedocs.blob.core.windows.net/apim-gko-auth/index.html)
<!-- UI placeholder end -->
