### PR TITLE
[APIM] Add changelog for new 3.15.19 release

### DIFF
--- a/pages/apim/3.x/changelog/changelog-3.15.adoc
+++ b/pages/apim/3.x/changelog/changelog-3.15.adoc
@@ -15,21 +15,23 @@ For upgrade instructions, please refer to https://docs.gravitee.io/apim/3.x/apim
  
 == APIM - 3.15.19 (2022-12-09)
 
-=== Gateway
 
-// TODO: List all Bug fixes & Improvements
+== APIM - 3.15.19 (2022-12-09)
 
-=== API
+=== Bug fixes
 
-// TODO: List all Bug fixes & Improvements
 
-=== Console
+*_General_*
 
-// TODO: List all Bug fixes & Improvements
+- Handle auth methods in mail configuration https://github.com/gravitee-io/issues/issues/8655[#8655]
 
-=== Portal
+*_Portal_*
 
-// TODO: List all Bug fixes & Improvements
+- In the metadata tab the field for name is not in English https://github.com/gravitee-io/issues/issues/7235[#7235]
+
+*_Management_*
+
+- Duplicate users on login when special characters in username https://github.com/gravitee-io/issues/issues/8673[#8673]
 
 
 == https://github.com/gravitee-io/issues/milestone/614?closed=1[APIM - 3.15.18 (2022-11-18)]

--- a/pages/apim/3.x/changelog/changelog-3.15.adoc
+++ b/pages/apim/3.x/changelog/changelog-3.15.adoc
@@ -12,6 +12,25 @@ For upgrade instructions, please refer to https://docs.gravitee.io/apim/3.x/apim
 // NOTE: Global 3.15 release info here
 
 // <DO NOT REMOVE THIS COMMENT - ANCHOR FOR FUTURE RELEASES>
+ 
+== APIM - 3.15.19 (2022-12-09)
+
+=== Gateway
+
+// TODO: List all Bug fixes & Improvements
+
+=== API
+
+// TODO: List all Bug fixes & Improvements
+
+=== Console
+
+// TODO: List all Bug fixes & Improvements
+
+=== Portal
+
+// TODO: List all Bug fixes & Improvements
+
 
 == https://github.com/gravitee-io/issues/milestone/614?closed=1[APIM - 3.15.18 (2022-11-18)]
 

--- a/pages/apim/3.x/changelog/changelog-3.15.adoc
+++ b/pages/apim/3.x/changelog/changelog-3.15.adoc
@@ -13,7 +13,6 @@ For upgrade instructions, please refer to https://docs.gravitee.io/apim/3.x/apim
 
 // <DO NOT REMOVE THIS COMMENT - ANCHOR FOR FUTURE RELEASES>
  
-== APIM - 3.15.19 (2022-12-09)
 
 
 == APIM - 3.15.19 (2022-12-09)


### PR DESCRIPTION
# New APIM version 3.15.19 has been released
📝 You can modify the changelog template online [here](https://github.com/gravitee-io/gravitee-docs/edit/release-apim-3.15.19/pages/apim/3.x/changelog/changelog-3.15.adoc)

Here is some information to help with the writing: 

## Pull Requests
<details>
  <summary>See all Pull Requests</summary>
 
### [feat: handle alert email-notifier and default-email authMethods [2725]](https://github.com/gravitee-io/gravitee-api-management/pull/2725)
- feat: handle alert email-notifier and default-email authMethods
### [fix(apim): remove metadata name placeholder [2706]](https://github.com/gravitee-io/gravitee-api-management/pull/2706)
- fix(apim): remove metadata name placeholder
### [escape all special characters when looking for a user - 3.15.x [2733]](https://github.com/gravitee-io/gravitee-api-management/pull/2733)
- fix: escape all special characters when looking for a user

</details>

## Jira issues

[See all Jira issues for 3.15.x version](https://gravitee.atlassian.net/jira/software/c/projects/APIM/issues/?jql=project%20%3D%20%22APIM%22%20and%20fixVersion%20%3D%203.15.x%20and%20status%20%3D%20Done%20ORDER%20BY%20created%20DESC)
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://graviteedocs.blob.core.windows.net/release-apim-3-15-19/index.html)
<!-- UI placeholder end -->
