### PR TITLE
[APIM] Add changelog for new 3.18.14 release

### DIFF
--- a/pages/apim/3.x/changelog/changelog-3.18.adoc
+++ b/pages/apim/3.x/changelog/changelog-3.18.adoc
@@ -15,22 +15,10 @@ For upgrade instructions, please refer to https://docs.gravitee.io/apim/3.x/apim
  
 == APIM - 3.18.14 (2022-12-16)
 
-=== Gateway
+=== General
 
-// TODO: List all Bug fixes & Improvements
-
-=== API
-
-// TODO: List all Bug fixes & Improvements
-
-=== Console
-
-// TODO: List all Bug fixes & Improvements
-
-=== Portal
-
-// TODO: List all Bug fixes & Improvements
-
+* Dynamic property schedule is now updateable 
+* Log details no longer fail with closed OAuth 2 or JWT plan
 
 == https://github.com/gravitee-io/issues/milestone/615?closed=1[APIM - 3.18.13 (2022-11-25)]
 

--- a/pages/apim/3.x/changelog/changelog-3.18.adoc
+++ b/pages/apim/3.x/changelog/changelog-3.18.adoc
@@ -12,6 +12,25 @@ For upgrade instructions, please refer to https://docs.gravitee.io/apim/3.x/apim
 // NOTE: Global 3.18 release info here
 
 // <DO NOT REMOVE THIS COMMENT - ANCHOR FOR FUTURE RELEASES>
+ 
+== APIM - 3.18.14 (2022-12-16)
+
+=== Gateway
+
+// TODO: List all Bug fixes & Improvements
+
+=== API
+
+// TODO: List all Bug fixes & Improvements
+
+=== Console
+
+// TODO: List all Bug fixes & Improvements
+
+=== Portal
+
+// TODO: List all Bug fixes & Improvements
+
 
 == https://github.com/gravitee-io/issues/milestone/615?closed=1[APIM - 3.18.13 (2022-11-25)]
 

--- a/pages/apim/3.x/changelog/changelog-3.18.adoc
+++ b/pages/apim/3.x/changelog/changelog-3.18.adoc
@@ -19,6 +19,7 @@ For upgrade instructions, please refer to https://docs.gravitee.io/apim/3.x/apim
 
 * Dynamic property schedule is now updateable 
 * Log details no longer fail with closed OAuth 2 or JWT plan
+* Optimized database access when searching APIs
 
 == https://github.com/gravitee-io/issues/milestone/615?closed=1[APIM - 3.18.13 (2022-11-25)]
 


### PR DESCRIPTION
# New APIM version 3.18.14 has been released
📝 You can modify the changelog template online [here](https://github.com/gravitee-io/gravitee-docs/edit/release-apim-3.18.14/pages/apim/3.x/changelog/changelog-3.18.adoc)

Here is some information to help with the writing:

## Pull requests
<details>
  <summary>See all Pull Requests</summary>

### [perf(mongodb): optimize database access when searching APIs [2835]](https://github.com/gravitee-io/gravitee-api-management/pull/2835)
- perf(mongodb): optimize database access when searching APIs
### [Fix ApiPrimaryOwnerRemoval upgrader [2829]](https://github.com/gravitee-io/gravitee-api-management/pull/2829)
- fix: pagination class was not well created
### [fix: manage multiple accept headers with quality factor [2809]](https://github.com/gravitee-io/gravitee-api-management/pull/2809)
- fix: manage multiple accept headers with quality factor https://gravitee.atlassian.net/browse/APIM-143
### [fix: dynamic property updates [2769]](https://github.com/gravitee-io/gravitee-api-management/pull/2769)
- fix: handle dynamic property changes on deploy
### [fix: dynamic property updates [2769]](https://github.com/gravitee-io/gravitee-api-management/pull/2769)
- fix: handle schedule in dynamic property ui
### [fix: trigger search on api subscriptions component init [2764]](https://github.com/gravitee-io/gravitee-api-management/pull/2764)
- fix: trigger search on api subscriptions component init
### [fix: restore archived applications in log filters [2763]](https://github.com/gravitee-io/gravitee-api-management/pull/2763)
- fix: restore archived applications in log filters
### [fix(gateway): map ssl configuration to debug http server [2750]](https://github.com/gravitee-io/gravitee-api-management/pull/2750)
- fix(gateway): map ssl configuration to debug http server
### [fix: catch plan not found exception when accessing log details [2752]](https://github.com/gravitee-io/gravitee-api-management/pull/2752)
- fix: catch plan not found exception when accessing log details
### [feat: handle alert email-notifier and default-email authMethods [2725]](https://github.com/gravitee-io/gravitee-api-management/pull/2725)
- feat: handle alert email-notifier and default-email authMethods
### [fix(apim): remove metadata name placeholder [2706]](https://github.com/gravitee-io/gravitee-api-management/pull/2706)
- fix(apim): remove metadata name placeholder
### [escape all special characters when looking for a user - 3.15.x [2733]](https://github.com/gravitee-io/gravitee-api-management/pull/2733)
- fix: escape all special characters when looking for a user


</details>

## Jira issues

[See all Jira issues for 3.18.x version](https://gravitee.atlassian.net/jira/software/c/projects/APIM/issues/?jql=project%20%3D%20%22APIM%22%20and%20fixVersion%20%3D%203.18.14%20and%20status%20%3D%20Done%20ORDER%20BY%20created%20DESC)
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://graviteedocs.blob.core.windows.net/release-apim-3-18-14/index.html)
<!-- UI placeholder end -->
