### PR TITLE
add breaking change note in APIM upgrade guide about AE new default behaviour

### DIFF
--- a/pages/apim/3.x/installation-guide/installation-guide-migration.adoc
+++ b/pages/apim/3.x/installation-guide/installation-guide-migration.adoc
@@ -13,6 +13,8 @@ You may be required to perform manual actions as part of the upgrade.
 WARNING: Be sure to run scripts on the correct database since `gravitee` is not always the default database!
 Check your db name by running `show dbs;`
 
+include::upgrades/3.20.0/README.adoc[leveloffset=+1]
+
 include::upgrades/3.19.0/README.adoc[leveloffset=+1]
 
 include::upgrades/3.18.10/README.adoc[leveloffset=+1]

--- a/pages/apim/3.x/installation-guide/upgrades/3.20.0/README.adoc
+++ b/pages/apim/3.x/installation-guide/upgrades/3.20.0/README.adoc
@@ -1,0 +1,17 @@
+= Upgrade to 3.20.0
+
+== Breaking changes
+
+=== Alert Engine
+Starting with 3.20.0, APIM is shipped with the new 2.0.0 version of the AlertEngine connector.
+
+Events are sent over http as default behaviour. In order to switch back to websocket:
+
+```yaml
+alerts:
+  alert-engine:
+    ws:
+      sendEventsOnHttp: false
+```
+
+Please see the link:/ae/apim_installation.html#event_sending_mode[AlertEngine documentation] for more information.


### PR DESCRIPTION
**Issue**

N/A

**Description**

Add breaking change note in APIM upgrade guide about AE new default behaviour
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://graviteedocs.blob.core.windows.net/add-note-in-apim-upgrade-guide/index.html)
<!-- UI placeholder end -->
