### PR TITLE
docs: add upgrade guide for 3.15.20

### DIFF
--- a/pages/apim/3.x/installation-guide/installation-guide-migration.adoc
+++ b/pages/apim/3.x/installation-guide/installation-guide-migration.adoc
@@ -35,6 +35,8 @@ include::upgrades/3.16.2/README.adoc[leveloffset=+1]
 
 include::upgrades/3.16.0/README.adoc[leveloffset=+1]
 
+include::upgrades/3.15.20/README.adoc[leveloffset=+1]
+
 include::upgrades/3.15.17/README.adoc[leveloffset=+1]
 
 include::upgrades/3.15.14/README.adoc[leveloffset=+1]

--- a/pages/apim/3.x/installation-guide/upgrades/3.15.20/README.adoc
+++ b/pages/apim/3.x/installation-guide/upgrades/3.15.20/README.adoc
@@ -1,0 +1,17 @@
+= Upgrade to 3.15.20
+
+== Breaking changes
+
+From this version, the embedded link:/apim/3.x/apim_policies_xslt.html[XSLT policy] has been updated to version 2.0.0.
+For security reasons, default behaviour has changed and some configuration options have been added.
+
+By default, a DOCTYPE declaration will cause an error. This is for security.
+If you want to allow it, you can set `policy.xslt.secure-processing` to `false` in the Gateway configuration file (`gravitee.yml`).
+
+[source, yaml]
+.Configuration
+----
+policy:
+  xslt:
+    secure-processing: false
+----


### PR DESCRIPTION
**Issue**

N/A

**Description**

Since APIM 3.15.20, we use the version 2.0.0 of the XSLT policy that comes with a breaking change in the configuration.
This PR warns users about this change
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://graviteedocs.blob.core.windows.net/breaking-change-in-policy-xslt/index.html)
<!-- UI placeholder end -->
