### PR TITLE
[APIM] Add changelog for new 3.18.15 release

### DIFF
--- a/pages/apim/3.x/changelog/changelog-3.18.adoc
+++ b/pages/apim/3.x/changelog/changelog-3.18.adoc
@@ -13,6 +13,25 @@ For upgrade instructions, please refer to https://docs.gravitee.io/apim/3.x/apim
 
 // <DO NOT REMOVE THIS COMMENT - ANCHOR FOR FUTURE RELEASES>
  
+== APIM - 3.18.15 (2023-01-03)
+
+=== Gateway
+
+// TODO: List all Bug fixes & Improvements
+
+=== API
+
+// TODO: List all Bug fixes & Improvements
+
+=== Console
+
+// TODO: List all Bug fixes & Improvements
+
+=== Portal
+
+// TODO: List all Bug fixes & Improvements
+
+ 
 == APIM - 3.18.14 (2022-12-16)
 
 === General

--- a/pages/apim/3.x/changelog/changelog-3.18.adoc
+++ b/pages/apim/3.x/changelog/changelog-3.18.adoc
@@ -17,20 +17,14 @@ For upgrade instructions, please refer to https://docs.gravitee.io/apim/3.x/apim
 
 === Gateway
 
-// TODO: List all Bug fixes & Improvements
+* API key plan was not useable after migration to 3.18
+* Non-explicit "invalid version format: 0" log message fixed
 
-=== API
+=== Management
 
-// TODO: List all Bug fixes & Improvements
-
-=== Console
-
-// TODO: List all Bug fixes & Improvements
-
-=== Portal
-
-// TODO: List all Bug fixes & Improvements
-
+* PostgreSQL: management API failed to start after 3.18 migration
+* Import API erased plan general conditions
+* API key revocation raised an error in non-default environment
  
 == APIM - 3.18.14 (2022-12-16)
 


### PR DESCRIPTION
# New APIM version 3.18.15 has been released
📝 You can modify the changelog template online [here](https://github.com/gravitee-io/gravitee-docs/edit/release-apim-3.18.15/pages/apim/3.x/changelog/changelog-3.18.adoc)

Here is some information to help with the writing:

## Pull requests
<details>
  <summary>See all Pull Requests</summary>

### [fix(postgreSQL): 3.18.0 migration script handle existing commands [2876]](https://github.com/gravitee-io/gravitee-api-management/pull/2876)
- fix(postgreSQL): 3.18.0 migration script handle existing commands
### [fix: recalculate plan general conditions page id during API import [2873]](https://github.com/gravitee-io/gravitee-api-management/pull/2873)
- fix: recalculate plan general conditions page id during API import
### [fix: check application apiKey mode according to environment in request [2871]](https://github.com/gravitee-io/gravitee-api-management/pull/2871)
- fix: check application apiKey mode according to environment in request
### [fix: API deserialization set plan.api from api.id if not in definition [2866]](https://github.com/gravitee-io/gravitee-api-management/pull/2866)
- fix: API deserialization set plan.api from api.id if not in definition
### [If dictionary provider method isn't defined then set it to GET  [2857]](https://github.com/gravitee-io/gravitee-api-management/pull/2857)
- fix: if dictionary provider method isn't defined then set it to GET
### [3.18.x refactor use of api search [2837]](https://github.com/gravitee-io/gravitee-api-management/pull/2837)
- fix(api): scope group associate by environment
### [Add primary keys on all tables as MySQL clusters require it [2808]](https://github.com/gravitee-io/gravitee-api-management/pull/2808)
- fix: add primary keys on all tables as MySQL cluster requires it
### [Use correct permissions in the menu of the organization settings screen  [2842]](https://github.com/gravitee-io/gravitee-api-management/pull/2842)
- fix: use correct permission to display Gateway menu items in organization settings
### [Handle wildcard in SimpleFailureProcessor [2840]](https://github.com/gravitee-io/gravitee-api-management/pull/2840)
- fix: handle wildcard in SimpleFailureProcessor


</details>

## Jira issues

[See all Jira issues for 3.18.x version](https://gravitee.atlassian.net/jira/software/c/projects/APIM/issues/?jql=project%20%3D%20%22APIM%22%20and%20fixVersion%20%3D%203.18.15%20and%20status%20%3D%20Done%20ORDER%20BY%20created%20DESC)
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://graviteedocs.blob.core.windows.net/release-apim-3-18-15/index.html)
<!-- UI placeholder end -->
