### PR TITLE
[APIM] Add changelog for new 3.18.16 release

### DIFF
--- a/pages/apim/3.x/changelog/changelog-3.18.adoc
+++ b/pages/apim/3.x/changelog/changelog-3.18.adoc
@@ -13,6 +13,15 @@ For upgrade instructions, please refer to https://docs.gravitee.io/apim/3.x/apim
 
 // <DO NOT REMOVE THIS COMMENT - ANCHOR FOR FUTURE RELEASES>
  
+== APIM - 3.18.16 (2023-01-04)
+
+=== API
+
+* Handle flow steps order in database https://github.com/gravitee-io/issues/issues/8805[#8805]
+* Handle query with page number higher than max page with data https://github.com/gravitee-io/issues/issues/8773[#8773]
+
+
+
 == APIM - 3.18.15 (2023-01-03)
 
 === Gateway


### PR DESCRIPTION

# New APIM version 3.18.16 has been released
📝 You can modify the changelog template online [here](https://github.com/gravitee-io/gravitee-docs/edit/release-apim-3.18.16/pages/apim/3.x/changelog/changelog-3.18.adoc)

Here is some information to help with the writing:

## Pull requests
<details>
  <summary>See all Pull Requests</summary>

### [fix(jdbc): handle query with page number higher than max page with data [2884]](https://github.com/gravitee-io/gravitee-api-management/pull/2884)
- fix(jdbc): handle query with page number higher than max page with data
### [Handle flow step order in database - 3.15 [2885]](https://github.com/gravitee-io/gravitee-api-management/pull/2885)
- fix: handle flow step order in database

</details>

## Jira issues

[See all Jira issues for 3.18.x version](https://gravitee.atlassian.net/jira/software/c/projects/APIM/issues/?jql=project%20%3D%20%22APIM%22%20and%20fixVersion%20%3D%203.18.16%20and%20status%20%3D%20Done%20ORDER%20BY%20created%20DESC)
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://graviteedocs.blob.core.windows.net/release-apim-3-18-16/index.html)
<!-- UI placeholder end -->
