### PR TITLE
Add upgrade note about xslt policy breaking change

### DIFF
--- a/pages/apim/3.x/installation-guide/upgrades/3.20.0/README.adoc
+++ b/pages/apim/3.x/installation-guide/upgrades/3.20.0/README.adoc
@@ -15,3 +15,18 @@ alerts:
 ```
 
 Please see the link:/ae/apim_installation.html#event_sending_mode[AlertEngine documentation] for more information.
+
+=== Policy XSLT
+From this version, the embedded link:/apim/3.x/apim_policies_xslt.html[XSLT policy] has been updated to version 2.0.0.
+For security reasons, default behaviour has changed and some configuration options have been added.
+
+By default, a DOCTYPE declaration will cause an error. This is for security.
+If you want to allow it, you can set `policy.xslt.secure-processing` to `false` in the Gateway configuration file (`gravitee.yml`).
+
+[source, yaml]
+.Configuration
+----
+policy:
+  xslt:
+    secure-processing: false
+----


### PR DESCRIPTION
**Issue**

N/A

**Description**

Since APIM 3.20.0, we use the version 2.0.0 of the XSLT policy that comes with a breaking change in the configuration.
This PR warns users about this change
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://graviteedocs.blob.core.windows.net/add-xslt-policy-bc-in-upgrade-note/index.html)
<!-- UI placeholder end -->
