### PR TITLE
[APIM] Add changelog for new 3.19.5 release

### DIFF
--- a/pages/apim/3.x/changelog/changelog-3.19.adoc
+++ b/pages/apim/3.x/changelog/changelog-3.19.adoc
@@ -12,6 +12,26 @@ For upgrade instructions, please refer to https://docs.gravitee.io/apim/3.x/apim
 // NOTE: Global 3.19 release info here
 
 // <DO NOT REMOVE THIS COMMENT - ANCHOR FOR FUTURE RELEASES>
+ 
+== APIM - 3.19.5 (2023-01-04)
+
+=== Gateway
+
+* API key plan was not useable after migration to 3.18
+* Non-explicit "invalid version format: 0" log message fixed
+
+=== API
+
+* Handle flow steps order in database https://github.com/gravitee-io/issues/issues/8805[#8805]
+* Handle query with page number higher than max page with data https://github.com/gravitee-io/issues/issues/8773[#8773]
+* PostgreSQL: management API failed to start after 3.18 migration
+* Import API erased plan general conditions
+* API key revocation raised an error in non-default environment
+
+=== Portal
+
+* Category name was not properly displayed on API page
+
 
 == https://github.com/gravitee-io/issues/milestone/620?closed=1[APIM - 3.19.4 (2022-12-02)]
 


### PR DESCRIPTION

# New APIM version 3.19.5 has been released
📝 You can modify the changelog template online [here](https://github.com/gravitee-io/gravitee-docs/edit/release-apim-3.19.5/pages/apim/3.x/changelog/changelog-3.19.adoc)

Here is some information to help with the writing:

## Pull requests
<details>
  <summary>See all Pull Requests</summary>

### [fix(jdbc): handle query with page number higher than max page with data [2884]](https://github.com/gravitee-io/gravitee-api-management/pull/2884)
- fix(jdbc): handle query with page number higher than max page with data
### [Handle flow step order in database - 3.15 [2885]](https://github.com/gravitee-io/gravitee-api-management/pull/2885)
- fix: handle flow step order in database
### [fix(postgreSQL): 3.18.0 migration script handle existing commands [2875]](https://github.com/gravitee-io/gravitee-api-management/pull/2875)
- fix(postgreSQL): 3.18.0 migration script handle existing commands
### [fix: API deserialization set plan.api from api.id if not in definition [2867]](https://github.com/gravitee-io/gravitee-api-management/pull/2867)
- fix: API deserialization set plan.api from api.id if not in definition
### [Merge 3.18.4 into 3.19.x [2839]](https://github.com/gravitee-io/gravitee-api-management/pull/2839)
- fix: handle wildcard in SimpleFailureProcessor
### [Use `key` attribute instead of `id` in the `categories` of an API [2826]](https://github.com/gravitee-io/gravitee-api-management/pull/2826)
- fix: use key attribute instead id in the categories of an API
### [fix: check subscriptions ids before evict [2656]](https://github.com/gravitee-io/gravitee-api-management/pull/2656)
- fix: check subscriptions ids before evict
### [fix: disable DOCTYPE usage for wsdl imports [ 3.19.x ] [2667]](https://github.com/gravitee-io/gravitee-api-management/pull/2667)
- fix: disable DOCTYPE usage for wsdl imports
### [[3.19.x] handle huge payload from cockpit controller [2641]](https://github.com/gravitee-io/gravitee-api-management/pull/2641)
- fix: handle huge payload from cockpit controller
### [fix(search): exclude V4 apis from search result [2583]](https://github.com/gravitee-io/gravitee-api-management/pull/2583)
- fix(search): exclude V4 apis from search result
### [fix(gateway): make API v1 paths based with API key plan work [2577]](https://github.com/gravitee-io/gravitee-api-management/pull/2577)
- fix(gateway): make API v1 paths based with API key plan work
### [fix: bump expression-language dependency fixes nested expressions [2551]](https://github.com/gravitee-io/gravitee-api-management/pull/2551)
- fix: bump expression-language dependency fixes nested expressions
### [fix(test-sdk): restore the entrypoints registration [2548]](https://github.com/gravitee-io/gravitee-api-management/pull/2548)
- fix(test-sdk): restore the entrypoints registration
### [Merge 3 19 0 master [2547]](https://github.com/gravitee-io/gravitee-api-management/pull/2547)
- feat(ui): add Content Security Policies in default nginx configuration for console and portal
### [Merge 3 19 0 master [2547]](https://github.com/gravitee-io/gravitee-api-management/pull/2547)
- feat: move SSE entrypoint to its own repository
### [Merge 3 19 0 master [2547]](https://github.com/gravitee-io/gravitee-api-management/pull/2547)
- fix: fix typo and unit tests
### [Merge 3 19 0 master [2547]](https://github.com/gravitee-io/gravitee-api-management/pull/2547)
- fix(typo): update-api-case
### [Merge 3 19 0 master [2547]](https://github.com/gravitee-io/gravitee-api-management/pull/2547)
- fix: apikey plan selection jupiter mode
### [package endpoints & entrypoints when releasing [2511]](https://github.com/gravitee-io/gravitee-api-management/pull/2511)
- feat: package endpoints & entrypoints
### [Merge 3 19 0 master [2547]](https://github.com/gravitee-io/gravitee-api-management/pull/2547)
- fix: add an index to improve apikeys sync [skip ci]
### [Fix ApiKey plan selection [2504]](https://github.com/gravitee-io/gravitee-api-management/pull/2504)
- fix: multi oauth plan selection
### [Fix ApiKey plan selection [2504]](https://github.com/gravitee-io/gravitee-api-management/pull/2504)
- fix: apikey plan selection
### [Merge 3 19 0 master [2547]](https://github.com/gravitee-io/gravitee-api-management/pull/2547)
- fix: pom.xml to reduce vulnerabilities
### [Improve VersionUtils to be able to parse non stable versions [2496]](https://github.com/gravitee-io/gravitee-api-management/pull/2496)
- fix: improve VersionUtils to be able to parse non stable versions
### [fix: bump expression-language to version 1.11.2 includes bugfixes from 1.9.x [2484]](https://github.com/gravitee-io/gravitee-api-management/pull/2484)
- fix: bump expression-language to version 1.11.2 includes bugfixes from 1.9.x
### [Fix heartbeat Service  [2425]](https://github.com/gravitee-io/gravitee-api-management/pull/2425)
- fix: fix HeartbeatService by removing Event state at the correct place
### [Merge master into 319x [2414]](https://github.com/gravitee-io/gravitee-api-management/pull/2414)
- fix: plan selection for v3 engine
### [feat: improve execution context structure [2398]](https://github.com/gravitee-io/gravitee-api-management/pull/2398)
- feat: improve message structure
### [feat: improve execution context structure [2398]](https://github.com/gravitee-io/gravitee-api-management/pull/2398)
- feat: improve execution context structure
### [Merge master into 319x [2414]](https://github.com/gravitee-io/gravitee-api-management/pull/2414)
- fix: pom.xml to reduce vulnerabilities
### [fix ci for alpha releases [2407]](https://github.com/gravitee-io/gravitee-api-management/pull/2407)
- fix(ci): use the version with modifier to change build.json files and for the tag
### [try to fix hearbeatservice like in 3.10.x [2405]](https://github.com/gravitee-io/gravitee-api-management/pull/2405)
- fix: try to fix hearbeatservice like in 3.10.x
### [feat: turn V4 EndpointGroup configuration to a json object [2404]](https://github.com/gravitee-io/gravitee-api-management/pull/2404)
- feat: turn V4 EndpointGroup configuration to a json object
### [feat: replace old api list page with the new one [2392]](https://github.com/gravitee-io/gravitee-api-management/pull/2392)
- feat: replace old api list page with the new one
### [feat: improve authentication workflow of subscription based plans [2397]](https://github.com/gravitee-io/gravitee-api-management/pull/2397)
- feat: improve authentication workflow of subscription based plans
### [fix: make gateway apply request timeout properly [2399]](https://github.com/gravitee-io/gravitee-api-management/pull/2399)
- fix: make gateway apply request timeout properly
### [fix(kafka): fix classloading while dealing with kafka objects [2396]](https://github.com/gravitee-io/gravitee-api-management/pull/2396)
- fix(kafka): fix classloading while dealing with kafka objects
### [Fix/merge 3187 319 run e2e [2393]](https://github.com/gravitee-io/gravitee-api-management/pull/2393)
- fix: bump `gravitee-connector-api` to `1.1.4`
### [Fix/merge 3187 319 run e2e [2393]](https://github.com/gravitee-io/gravitee-api-management/pull/2393)
- fix: bump `gravitee-connector-http` to `2.0.5`
### [Fix/merge 3187 319 run e2e [2393]](https://github.com/gravitee-io/gravitee-api-management/pull/2393)
- fix: fix 3.18.7 merge
### [fix(deps): update @toast-ui/editor to v2.5.4 [2249]](https://github.com/gravitee-io/gravitee-api-management/pull/2249)
- fix(deps): update @toast-ui/editor to v2.5.4
### [fix(deps): update @gravitee/ui-components to v3.36.2 [2329]](https://github.com/gravitee-io/gravitee-api-management/pull/2329)
- fix(deps): update @gravitee/ui-components to v3.36.2
### [8291 improve entrypoints quality [2381]](https://github.com/gravitee-io/gravitee-api-management/pull/2381)
- fix(): rename model class where prefix should be the specialization
### [feat: add origin in api list and search [2391]](https://github.com/gravitee-io/gravitee-api-management/pull/2391)
- feat: add origin in search engine
### [feat: add origin in api list and search [2391]](https://github.com/gravitee-io/gravitee-api-management/pull/2391)
- feat: display kubernes icon for gko apis
### [feat: add origin in api list and search [2391]](https://github.com/gravitee-io/gravitee-api-management/pull/2391)
- feat: list apis with origin
### [fix(deps): update @gravitee/ui-analytics to v3.6.0 [2221]](https://github.com/gravitee-io/gravitee-api-management/pull/2221)
- fix(deps): update @gravitee/ui-analytics to v3.6.0
### [Issues/#8142 add filters and columns in api list [2380]](https://github.com/gravitee-io/gravitee-api-management/pull/2380)
- feat: add loading state in table
### [Issues/#8142 add filters and columns in api list [2380]](https://github.com/gravitee-io/gravitee-api-management/pull/2380)
- feat: adapt search bar size
### [Issues/#8142 add filters and columns in api list [2380]](https://github.com/gravitee-io/gravitee-api-management/pull/2380)
- feat: add edit action
### [Issues/#8142 add filters and columns in api list [2380]](https://github.com/gravitee-io/gravitee-api-management/pull/2380)
- feat: use search engine
### [Issues/#8142 add filters and columns in api list [2380]](https://github.com/gravitee-io/gravitee-api-management/pull/2380)
- feat: add visibility column
### [Issues/#8142 add filters and columns in api list [2380]](https://github.com/gravitee-io/gravitee-api-management/pull/2380)
- feat: add quality score column
### [Issues/#8142 add filters and columns in api list [2380]](https://github.com/gravitee-io/gravitee-api-management/pull/2380)
- feat: add out of sync icon
### [Issues/#8142 add filters and columns in api list [2380]](https://github.com/gravitee-io/gravitee-api-management/pull/2380)
- feat: add api icons
### [Issues/#8142 add filters and columns in api list [2380]](https://github.com/gravitee-io/gravitee-api-management/pull/2380)
- feat: add columns
### [Issues/#8142 add filters and columns in api list [2380]](https://github.com/gravitee-io/gravitee-api-management/pull/2380)
- feat: add filters on apis list page
### [HTTP-Post entrypoint [2374]](https://github.com/gravitee-io/gravitee-api-management/pull/2374)
- feat(entrypoint): add a new http-post entrypoint
### [HTTP-Post entrypoint [2374]](https://github.com/gravitee-io/gravitee-api-management/pull/2374)
- feat(message): access body from VertxMessageServerRequest
### [HTTP-Post entrypoint [2374]](https://github.com/gravitee-io/gravitee-api-management/pull/2374)
- feat(mock-endpoint): log incoming message content
### [fix(e2e): ignore message with retry element [2385]](https://github.com/gravitee-io/gravitee-api-management/pull/2385)
- fix(e2e): ignore message with retry element
### [feat(kafka): add kafka endpoint [2379]](https://github.com/gravitee-io/gravitee-api-management/pull/2379)
- feat(kafka): add kafka endpoint
### [[Snyk] Security upgrade org.yaml:snakeyaml from 1.30 to 1.31 [2375]](https://github.com/gravitee-io/gravitee-api-management/pull/2375)
- fix: pom.xml to reduce vulnerabilities
### [Issues/#8142 new apis list screen [2368]](https://github.com/gravitee-io/gravitee-api-management/pull/2368)
- feat(console): fetch paged apis
### [Issues/#8142 new apis list screen [2368]](https://github.com/gravitee-io/gravitee-api-management/pull/2368)
- feat(console): inity empty apis table
### [Issues/#8142 new apis list screen [2368]](https://github.com/gravitee-io/gravitee-api-management/pull/2368)
- feat(console): add new apis
### [Issues/#8142 new apis list screen [2368]](https://github.com/gravitee-io/gravitee-api-management/pull/2368)
- feat(console): init api list screen migration
### [feat(perf): add keyless api scenario [2344]](https://github.com/gravitee-io/gravitee-api-management/pull/2344)
- feat(perf): add keyless api scenario
### [feat: delete api with kubernetes origin [2356]](https://github.com/gravitee-io/gravitee-api-management/pull/2356)
- feat: delete api with kubernetes origin
### [Gateway Testing SDK - Register Entrypoint plugins and deploy API V4 [2299]](https://github.com/gravitee-io/gravitee-api-management/pull/2299)
- feat: gateway testing sdk inject vertx HttpClient HttpClient is more flexible to handle async calls, so we are able to do assertions on chunks. WebClient is limited because he only returns the response as a Single gravitee-io/issues#8286
### [Gateway Testing SDK - Register Entrypoint plugins and deploy API V4 [2299]](https://github.com/gravitee-io/gravitee-api-management/pull/2299)
- feat: gateway testing sdk api V4 deployment
### [Gateway Testing SDK - Register Entrypoint plugins and deploy API V4 [2299]](https://github.com/gravitee-io/gravitee-api-management/pull/2299)
- feat: add endpoint registration in gateway testing sdk
### [Gateway Testing SDK - Register Entrypoint plugins and deploy API V4 [2299]](https://github.com/gravitee-io/gravitee-api-management/pull/2299)
- feat: add entrypoint registration in gateway testing sdk
### [Gko close all plans [2346]](https://github.com/gravitee-io/gravitee-api-management/pull/2346)
- feat(rest-api): close each plans when delete api from K8s Origin
### [use JDK 17 in every java jobs [2342]](https://github.com/gravitee-io/gravitee-api-management/pull/2342)
- fix: keep JDK 11 for community build
### [feat: handle endpoint inherited configuration [2316]](https://github.com/gravitee-io/gravitee-api-management/pull/2316)
- feat: handle endpoint inherited configuration
### [chore: explicit a swagger name for all V4 API model objects [2333]](https://github.com/gravitee-io/gravitee-api-management/pull/2333)
- fix: use the right EntrypointResource path variable name
### [Feat endpoint invoker [2318]](https://github.com/gravitee-io/gravitee-api-management/pull/2318)
- feat: add default values for mocl endpoint configuration
### [Feat endpoint invoker [2318]](https://github.com/gravitee-io/gravitee-api-management/pull/2318)
- feat: add messages count configuration in mock endpoint
### [Feat endpoint invoker [2318]](https://github.com/gravitee-io/gravitee-api-management/pull/2318)
- feat: implement endpoint invoker and resolver
### [Feat endpoint invoker [2318]](https://github.com/gravitee-io/gravitee-api-management/pull/2318)
- feat: validate jupiter connector plugins configurations
### [Feat endpoint invoker [2318]](https://github.com/gravitee-io/gravitee-api-management/pull/2318)
- feat: use milliseconds and singular in mock endpoint configuration
### [Feat endpoint invoker [2318]](https://github.com/gravitee-io/gravitee-api-management/pull/2318)
- feat: add EndpointInvoker and EndpointResolver
### [Feat endpoint invoker [2318]](https://github.com/gravitee-io/gravitee-api-management/pull/2318)
- feat: add endpoint plugin module, with mock endpoint
### [fix: add support failover for jupiter [2312]](https://github.com/gravitee-io/gravitee-api-management/pull/2312)
- fix: add support failover for jupiter
### [fix: fix bump to new version of gateway-api [2322]](https://github.com/gravitee-io/gravitee-api-management/pull/2322)
- fix: fix bump to new version of gateway-api
### [jupiter plan execution refactoring [2284]](https://github.com/gravitee-io/gravitee-api-management/pull/2284)
- feat: refactor the plan selection workflow
### [feat(rest-api): allow gko to start & stop api without publish event [2301]](https://github.com/gravitee-io/gravitee-api-management/pull/2301)
- feat(rest-api): allow gko to start & stop api without publish event
### [Allow set "definition context" only at creation [2308]](https://github.com/gravitee-io/gravitee-api-management/pull/2308)
- fix(rest-api): keep api created definition context
### [fix(gateway): fix flaky NullPointerException when k8s sync handleConf… [2296]](https://github.com/gravitee-io/gravitee-api-management/pull/2296)
- fix(gateway): fix flaky NullPointerException when k8s sync handleConfigMapEvent
### [fix: e2e v1 definition [2295]](https://github.com/gravitee-io/gravitee-api-management/pull/2295)
- fix: e2e v1 definition
### [#8238 Implement new plugin type to deal with EntryPoint [2255]](https://github.com/gravitee-io/gravitee-api-management/pull/2255)
- feat(gateway): handle v4 api deployment
### [#8238 Implement new plugin type to deal with EntryPoint [2255]](https://github.com/gravitee-io/gravitee-api-management/pull/2255)
- fix(rest): use new path service validation in both v2/v4 in order to check either virtualhost or path
### [#8238 Implement new plugin type to deal with EntryPoint [2255]](https://github.com/gravitee-io/gravitee-api-management/pull/2255)
- feat(entrypoint): add entrypoint plugin framework
### [#8238 Implement new plugin type to deal with EntryPoint [2255]](https://github.com/gravitee-io/gravitee-api-management/pull/2255)
- feat(definition): Allow to CRUD AsyncAPI
### [feat: deploy organization feature in gateway testing sdk  [2264]](https://github.com/gravitee-io/gravitee-api-management/pull/2264)
- feat: deploy organization feature in gateway testing sdk gravitee-io/issues#8184
### [escape a mysql/mariadb reserved word [2289]](https://github.com/gravitee-io/gravitee-api-management/pull/2289)
- fix(jdbc): escape a mysql/mariadb reserved word
### [fix: http request timeout refine default value assignation [2286]](https://github.com/gravitee-io/gravitee-api-management/pull/2286)
- fix: http request timeout refine default value assignation gravitee-io/issues#8273
### [Arch 179 - implement new model for async api [2215]](https://github.com/gravitee-io/gravitee-api-management/pull/2215)
- feat(definition): Allow to CRUD AsyncAPI
### [fix: fix typo in response template config [2282]](https://github.com/gravitee-io/gravitee-api-management/pull/2282)
- fix: fix typo in response template config
### [fix(rest-api): use snake_case everywhere for definition_context property [2280]](https://github.com/gravitee-io/gravitee-api-management/pull/2280)
- fix(rest-api): use snake_case everywhere for definition_context property
### [fix(gateway): disable `services.sync.kubernetes.enabled` by default [2272]](https://github.com/gravitee-io/gravitee-api-management/pull/2272)
- fix(gateway): disable `services.sync.kubernetes.enabled` by default
### [fix: add planId in subscription cache key [2241]](https://github.com/gravitee-io/gravitee-api-management/pull/2241)
- fix: add planId in subscription cache key
### [feat: handle reactive timeout  [2224]](https://github.com/gravitee-io/gravitee-api-management/pull/2224)
- feat: handle reactive timeout gravitee-io/issues#7988
### [feat: handle reactive timeout  [2224]](https://github.com/gravitee-io/gravitee-api-management/pull/2224)
- fix: return completable when no key for ResponseTemplateBasedFailureProcessor
### [feat(kubernetes): support api managed from k8s [2225]](https://github.com/gravitee-io/gravitee-api-management/pull/2225)
- fix(gko): do not write config map env twice
### [feat(kubernetes): support api managed from k8s [2225]](https://github.com/gravitee-io/gravitee-api-management/pull/2225)
- fix: set definition context on import
### [feat(kubernetes): support api managed from k8s [2225]](https://github.com/gravitee-io/gravitee-api-management/pull/2225)
- fix: format liquibase change set
### [feat(kubernetes): support api managed from k8s [2225]](https://github.com/gravitee-io/gravitee-api-management/pull/2225)
- feat(kubernetes): support api managed from k8s
### [fix: use a correct api definition and fix the test accordingly [2231]](https://github.com/gravitee-io/gravitee-api-management/pull/2231)
- fix: use a correct api definition and fix the test accordingly
### [refactor(jupiter): improve request/response body cache [2222]](https://github.com/gravitee-io/gravitee-api-management/pull/2222)
- fix: return null instead of empty list when getting an undefined header
### [test(e2e): fix api-import-by-url.spec.ts [2201]](https://github.com/gravitee-io/gravitee-api-management/pull/2201)
- fix(e2e): use good WIREMOCK_BASE_URL
### [fix: migration sdk keyless policy to jupiter [2202]](https://github.com/gravitee-io/gravitee-api-management/pull/2202)
- fix: migration sdk keyless policy to jupiter
### [Gateway container tests API to V2 [2182]](https://github.com/gravitee-io/gravitee-api-management/pull/2182)
- fix: use reason from invoker when handling response gravitee-io/issues#7993
### [fix(build): allow to use SNAPSHOT version of parent-pom for the build [2176]](https://github.com/gravitee-io/gravitee-api-management/pull/2176)
- fix(build): allow to use SNAPSHOT version of parent-pom for the build
### [[Snyk] Security upgrade moment from 2.29.2 to 2.29.4 [2153]](https://github.com/gravitee-io/gravitee-api-management/pull/2153)
- fix: gravitee-apim-console-webui/package.json & gravitee-apim-console-webui/package-lock.json to reduce vulnerabilities
### [feat(jupiter): websocket support [2151]](https://github.com/gravitee-io/gravitee-api-management/pull/2151)
- feat(jupiter): websocket support
### [test(e2e): run with jupiter mode enabled [2113]](https://github.com/gravitee-io/gravitee-api-management/pull/2113)
- fix: avoid NPE when trying to notify on an API deployment
### [refactor(e2e): change fetch gateway retry mechanism [2148]](https://github.com/gravitee-io/gravitee-api-management/pull/2148)
- fix(e2e): flaky tests
### [feat(jupiter): implement api logging support for jupiter [2104]](https://github.com/gravitee-io/gravitee-api-management/pull/2104)
- feat(jupiter): implement api logging support for jupiter
### [fix: run search index upgrader with admin role [2138]](https://github.com/gravitee-io/gravitee-api-management/pull/2138)
- fix: run search index upgrader with admin role
### [Fix e2e  [2130]](https://github.com/gravitee-io/gravitee-api-management/pull/2130)
- fix(e2e): give elastic more time to index 🤹 🤷‍♂️
### [Fix e2e  [2130]](https://github.com/gravitee-io/gravitee-api-management/pull/2130)
- fix(e2e): fix flaky e2e due to non waiting redeployment
### [Fix e2e  [2130]](https://github.com/gravitee-io/gravitee-api-management/pull/2130)
- fix(e2e): set api crossId to update plan by import
### [fix(jupiter): wait for pending requests before stoping reactor [2126]](https://github.com/gravitee-io/gravitee-api-management/pull/2126)
- fix(jupiter): wait for pending requests before stoping reactor
### [Merge 3.18.x into master [2120]](https://github.com/gravitee-io/gravitee-api-management/pull/2120)
- fix(gateway): use new DebugApiReactorHandlerFactory next to rewording
### [Merge 3.18.x into master [2120]](https://github.com/gravitee-io/gravitee-api-management/pull/2120)
- fix(e2e): fix tsc errors
### [fix: missing application in refreshed subscription [2112]](https://github.com/gravitee-io/gravitee-api-management/pull/2112)
- fix: missing application in refreshed subscription
### [fix(deps): update @gravitee/ui-components to v3.36.1 [2028]](https://github.com/gravitee-io/gravitee-api-management/pull/2028)
- fix(deps): update @gravitee/ui-components to v3.36.1
### [refactor: handle apiKey and subscriptions caches using cacheManagers instead of repositoryWrappers [2029]](https://github.com/gravitee-io/gravitee-api-management/pull/2029)
- feat: handle apiKey and subscriptions with dedicated services instead of repositoryWrappers
### [fix: use latest release version of gateway api [2075]](https://github.com/gravitee-io/gravitee-api-management/pull/2075)
- fix: use latest release version of gateway api
### [Implement debug mode for Jupiter [2050]](https://github.com/gravitee-io/gravitee-api-management/pull/2050)
- feat(jupiter): implementation of debug mode
### [fix(e2e): set wiremock `global-response-templating` option [2071]](https://github.com/gravitee-io/gravitee-api-management/pull/2071)
- fix(e2e): set wiremock `global-response-templating` option
### [[Snyk] Security upgrade org.springframework.data:spring-data-mongodb from 3.4.0 to 3.4.1 [2065]](https://github.com/gravitee-io/gravitee-api-management/pull/2065)
- fix: gravitee-apim-repository/gravitee-apim-repository-mongodb/pom.xml to reduce vulnerabilities
### [feat(jupiter): reactive expression language evaluation [2012]](https://github.com/gravitee-io/gravitee-api-management/pull/2012)
- feat(jupiter): reactive expression language evaluation
### [fix: compute total nb of apis while listing categories for settings page only [2036]](https://github.com/gravitee-io/gravitee-api-management/pull/2036)
- fix: compute total nb of apis while listing categories for settings page only

</details>

## Jira issues

[See all Jira issues for 3.19.x version](https://gravitee.atlassian.net/jira/software/c/projects/APIM/issues/?jql=project%20%3D%20%22APIM%22%20and%20fixVersion%20%3D%203.19.5%20and%20status%20%3D%20Done%20ORDER%20BY%20created%20DESC)
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://graviteedocs.blob.core.windows.net/release-apim-3-19-5/index.html)
<!-- UI placeholder end -->
