### PR TITLE
[APIM] Add changelog for new 3.18.17 release

### DIFF
--- a/pages/apim/3.x/changelog/changelog-3.18.adoc
+++ b/pages/apim/3.x/changelog/changelog-3.18.adoc
@@ -13,6 +13,14 @@ For upgrade instructions, please refer to https://docs.gravitee.io/apim/3.x/apim
 
 // <DO NOT REMOVE THIS COMMENT - ANCHOR FOR FUTURE RELEASES>
  
+== APIM - 3.18.17 (2023-01-04)
+
+=== API
+
+* Add a default value in liquibase script when adding a non-nullable constraint on `commands` table
+
+
+
 == APIM - 3.18.16 (2023-01-04)
 
 === API


### PR DESCRIPTION

# New APIM version 3.18.17 has been released
📝 You can modify the changelog template online [here](https://github.com/gravitee-io/gravitee-docs/edit/release-apim-3.18.17/pages/apim/3.x/changelog/changelog-3.18.adoc)

Here is some information to help with the writing:

## Pull requests
<details>
  <summary>See all Pull Requests</summary>

### [fix: disable checksum validation on liquibase 3.18.0 changeset [2891]](https://github.com/gravitee-io/gravitee-api-management/pull/2891)
- fix: disable checksum validation on liquibase 3.18.0 changeset

</details>

## Jira issues

[See all Jira issues for 3.18.x version](https://gravitee.atlassian.net/jira/software/c/projects/APIM/issues/?jql=project%20%3D%20%22APIM%22%20and%20fixVersion%20%3D%203.18.17%20and%20status%20%3D%20Done%20ORDER%20BY%20created%20DESC)
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://graviteedocs.blob.core.windows.net/release-apim-3-18-17/index.html)
<!-- UI placeholder end -->
