### PR TITLE
Update expression-language.adoc

### DIFF
--- a/pages/apim/3.x/user-guide/publisher/expression-language.adoc
+++ b/pages/apim/3.x/user-guide/publisher/expression-language.adoc
@@ -38,7 +38,7 @@ automatically _injected_ into the expression language context to be used later.
 
 === Dictionaries
 
-link:{{ 'apim/3.x/apim_installguide_configuration_dictionaries.html' | relative_url }}[Dictionaries] work in a similar way to properties, but you need to specify the dictionary name as well as the property name.
+link:{{ 'apim/3.x/apim_installguide_configuration_dictionaries.html' | relative_url }}[Dictionaries] work in a similar way to properties, but you need to specify the dictionary id (visible in the url) as well as the property name.
 
 ==== Example
 


### PR DESCRIPTION
Fix wrong EL doc. 
Dictionaries are accessed by id not name (visible in the url)

**Description**

Dictionaries are accessed by id not name (visible in the url)



