### PR TITLE
docs: the service name does not have "3x"

### DIFF
--- a/pages/apim/3.x/installation-guide/red-hat/installation-guide-redhat-stack.adoc
+++ b/pages/apim/3.x/installation-guide/red-hat/installation-guide-redhat-stack.adoc
@@ -7,6 +7,7 @@
 :page-keywords: Gravitee.io, API Platform, API Management, API Gateway, oauth2, openid, documentation, manual, guide, reference, api
 
 :gravitee-package-name: graviteeio-apim-3x
+:gravitee-service-name: graviteeio-apim
 
 == Overview
 
@@ -99,7 +100,7 @@ To start up the APIM components, run the following commands:
 [source,bash,subs="attributes"]
 ----
 sudo systemctl daemon-reload
-sudo systemctl start {gravitee-package-name}-gateway {gravitee-package-name}-management-api
+sudo systemctl start {gravitee-service-name}-gateway {gravitee-service-name}-rest-api
 sudo systemctl restart nginx
 ----
 


### PR DESCRIPTION
**Issue**

N/A

**Description**

Fix a small issue in RedHat documentation
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://graviteedocs.blob.core.windows.net/improvement-in-apim-rpm-installation/index.html)
<!-- UI placeholder end -->
