### PR TITLE
fix: use correct GitHub issue in `APIM - 3.19.5` changelog

### DIFF
--- a/pages/apim/3.x/changelog/changelog-3.19.adoc
+++ b/pages/apim/3.x/changelog/changelog-3.19.adoc
@@ -25,7 +25,7 @@ For upgrade instructions, please refer to https://docs.gravitee.io/apim/3.x/apim
 
 === Gateway
 
-* API key plan was not useable after migration to 3.18 https://github.com/gravitee-io/issues/issues/8762[#8762]
+* API key plan was not useable after migration to 3.18 https://github.com/gravitee-io/issues/issues/8763[#8763]
 * Non-explicit "invalid version format: 0" log message fixed https://github.com/gravitee-io/issues/issues/8754[#8754]
 
 === API


### PR DESCRIPTION
**Issue**

NA

**Description**

Use correct GitHub issue in `APIM - 3.19.5` changelog
Related to https://graviteeio.slack.com/archives/C02FBCEPQTT/p1674036414315009
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://graviteedocs.blob.core.windows.net/gaetanmaisse-patch-1/index.html)
<!-- UI placeholder end -->
