### PR TITLE
[APIM] Add changelog for new 3.15.22 release

### DIFF
--- a/pages/apim/3.x/changelog/changelog-3.15.adoc
+++ b/pages/apim/3.x/changelog/changelog-3.15.adoc
@@ -13,6 +13,13 @@ For upgrade instructions, please refer to https://docs.gravitee.io/apim/3.x/apim
 
 // <DO NOT REMOVE THIS COMMENT - ANCHOR FOR FUTURE RELEASES>
  
+== APIM - 3.15.22 (2023-01-20)
+
+=== API
+
+  - Duplicated platform flows when APIM is linked to Cockpit. https://github.com/gravitee-io/issues/issues/8832[#8832]
+  - Unable to start up with JDBC when platform flows have been defined with multiple steps on the same phase. https://github.com/gravitee-io/issues/issues/8816[#8816]
+ 
 == APIM - 3.15.21 (2023-01-04)
 
 === API


### PR DESCRIPTION

# New APIM version 3.15.22 has been released
📝 You can modify the changelog template online [here](https://github.com/gravitee-io/gravitee-docs/edit/release-apim-3.15.22/pages/apim/3.x/changelog/changelog-3.15.adoc)

Here is some information to help with the writing:

## Pull requests
<details>
  <summary>See all Pull Requests</summary>

### [fix cockpit hello command organisation update [2951]](https://github.com/gravitee-io/gravitee-api-management/pull/2951)
- fix(cockpit): make hello command reply update only organization
### [Fix Liquibase script's error on upgrade [2927]](https://github.com/gravitee-io/gravitee-api-management/pull/2927)
- fix(repository): change PK of flow_steps table to a new auto incremented column

</details>

## Jira issues

[See all Jira issues for 3.15.x version](https://gravitee.atlassian.net/jira/software/c/projects/APIM/issues/?jql=project%20%3D%20%22APIM%22%20and%20fixVersion%20%3D%203.15.22%20and%20status%20%3D%20Done%20ORDER%20BY%20created%20DESC)
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://graviteedocs.blob.core.windows.net/release-apim-3-15-22/index.html)
<!-- UI placeholder end -->
