### PR TITLE
[APIM] Add changelog for new 3.18.18 release

### DIFF
--- a/pages/apim/3.x/changelog/changelog-3.18.adoc
+++ b/pages/apim/3.x/changelog/changelog-3.18.adoc
@@ -16,7 +16,7 @@ For upgrade instructions, please refer to https://docs.gravitee.io/apim/3.x/apim
 == APIM - 3.18.18 (2023-01-27)
 
 === API
-* Plan policy were lost when migrated an API to design studio https://github.com/gravitee-io/issues/issues/8632[#8632]
+* Plan policies were lost when migrated from an API to design studio https://github.com/gravitee-io/issues/issues/8632[#8632]
 * Notifier email bump to 1.5.0 https://github.com/gravitee-io/issues/issues/8830[#8830]
 * Update flows condition max size to 512 https://github.com/gravitee-io/issues/issues/8823[#8823] & https://github.com/gravitee-io/issues/issues/8671[#8671]
 * Duplicated platform flows when APIM is linked to Cockpit. https://github.com/gravitee-io/issues/issues/8832[#8832]

--- a/pages/apim/3.x/changelog/changelog-3.18.adoc
+++ b/pages/apim/3.x/changelog/changelog-3.18.adoc
@@ -13,6 +13,21 @@ For upgrade instructions, please refer to https://docs.gravitee.io/apim/3.x/apim
 
 // <DO NOT REMOVE THIS COMMENT - ANCHOR FOR FUTURE RELEASES>
  
+== APIM - 3.18.18 (2023-01-27)
+
+=== API
+* Plan policy were lost when migrated an API to design studio https://github.com/gravitee-io/issues/issues/8632[#8632]
+* Notifier email bump to 1.5.0 https://github.com/gravitee-io/issues/issues/8830[#8830]
+* Update flows condition max size to 512 https://github.com/gravitee-io/issues/issues/8823[#8823] & https://github.com/gravitee-io/issues/issues/8671[#8671]
+* Duplicated platform flows when APIM is linked to Cockpit. https://github.com/gravitee-io/issues/issues/8832[#8832]
+* Unable to start up with JDBC when platform flows have been defined with multiple steps on the same phase. https://github.com/gravitee-io/issues/issues/8816[#8816]
+
+=== Gateway
+* API Subscription was not working after closing and re-creating https://github.com/gravitee-io/issues/issues/8600[#8600]
+* Add support from websocket frame compression https://github.com/gravitee-io/issues/issues/8689[#8689]
+* Exception "Error while determining deployed APIs store into events payload" fixed https://github.com/gravitee-io/issues/issues/8464[#8464]
+
+
 == APIM - 3.18.17 (2023-01-04)
 
 === API


### PR DESCRIPTION

# New APIM version 3.18.18 has been released
📝 You can modify the changelog template online [here](https://github.com/gravitee-io/gravitee-docs/edit/release-apim-3.18.18/pages/apim/3.x/changelog/changelog-3.18.adoc)

Here is some information to help with the writing:

## Pull requests
<details>
  <summary>See all Pull Requests</summary>

### [fix: bump data-logging-masking policy for dev env to 2.0.3 [2994]](https://github.com/gravitee-io/gravitee-api-management/pull/2994)
- fix: bump data-logging-masking policy for dev env to 2.0.3
### [Fix error message displayed when trying to publish 2 keyless plans [2984]](https://github.com/gravitee-io/gravitee-api-management/pull/2984)
- fix: fix error message displayed when trying to publish 2 keyless plan
### [Update flows condition max size to 512 [2982]](https://github.com/gravitee-io/gravitee-api-management/pull/2982)
- fix(jdbc): update flows condition max size to 512
### [feat: websocket frame compression support [2967]](https://github.com/gravitee-io/gravitee-api-management/pull/2967)
- feat: websocket frame compression support
### [Merge 3.15.22 into 3.18.x [2966]](https://github.com/gravitee-io/gravitee-api-management/pull/2966)
- fix(cockpit): make hello command reply update only organization
### [fix(cockpit): make hello command reply update only organization [2931]](https://github.com/gravitee-io/gravitee-api-management/pull/2931)
- fix(cockpit): make hello command reply update only organization
### [fix: email notifier 1.5.0 with authMethods downgraded in 3.18.x [2946]](https://github.com/gravitee-io/gravitee-api-management/pull/2946)
- fix: email notifier 1.5.0 with authMethods downgraded in 3.18.x
### [fix: resolve deployment of an api with group as primary owner [2932]](https://github.com/gravitee-io/gravitee-api-management/pull/2932)
- fix: resolve deployment of an api with group as primary owner
### [Fix Liquibase script's error on upgrade [2927]](https://github.com/gravitee-io/gravitee-api-management/pull/2927)
- fix(repository): change PK of flow_steps table to a new auto incremented column
### [fix: keep plan policies during migration [2916]](https://github.com/gravitee-io/gravitee-api-management/pull/2916)
- fix: keep plan policies during migration
### [fix: API key synchronization gives precedence to active keys [2905]](https://github.com/gravitee-io/gravitee-api-management/pull/2905)
- fix: API key synchronization gives precedence to active keys

</details>

## Jira issues

[See all Jira issues for 3.18.x version](https://gravitee.atlassian.net/jira/software/c/projects/APIM/issues/?jql=project%20%3D%20%22APIM%22%20and%20fixVersion%20%3D%203.18.18%20and%20status%20%3D%20Done%20ORDER%20BY%20created%20DESC)
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://graviteedocs.blob.core.windows.net/release-apim-3-18-18/index.html)
<!-- UI placeholder end -->
