### PR TITLE
[APIM] Add changelog for new 3.19.7 release

### DIFF
--- a/pages/apim/3.x/changelog/changelog-3.19.adoc
+++ b/pages/apim/3.x/changelog/changelog-3.19.adoc
@@ -13,6 +13,31 @@ For upgrade instructions, please refer to https://docs.gravitee.io/apim/3.x/apim
 
 // <DO NOT REMOVE THIS COMMENT - ANCHOR FOR FUTURE RELEASES>
  
+== APIM - 3.19.7 (2023-02-03)
+
+=== API
+* Plan policies were lost when migrated from an API to design studio https://github.com/gravitee-io/issues/issues/8632[#8632]
+* Bump Email Notifier to `1.5.0` https://github.com/gravitee-io/issues/issues/8830[#8830]
+* Update flows condition max size to 512 https://github.com/gravitee-io/issues/issues/8823[#8823] & https://github.com/gravitee-io/issues/issues/8671[#8671]
+* Duplicated platform flows when APIM is linked to Cockpit https://github.com/gravitee-io/issues/issues/8832[#8832]
+* Unable to start up with JDBC when platform flows have been defined with multiple steps on the same phase https://github.com/gravitee-io/issues/issues/8816[#8816]
+* Handle YAML Anchors and Alias when importing OpenAPI file https://github.com/gravitee-io/issues/issues/8858[#8858]
+
+=== Gateway
+* API Subscription was not working after closing and re-creating https://github.com/gravitee-io/issues/issues/8600[#8600]
+* Add support from websocket frame compression https://github.com/gravitee-io/issues/issues/8689[#8689]
+* Exception "Error while determining deployed APIs store into events payload" fixed https://github.com/gravitee-io/issues/issues/8464[#8464]
+* Do not save clientId in API key subscription https://github.com/gravitee-io/issues/issues/8855[#8855]
+
+=== Console
+
+* Display icons of APIs in API list screen https://github.com/gravitee-io/issues/issues/8809[#8809]
+* Global improvement on log filters https://github.com/gravitee-io/issues/issues/8822[#8822] & https://github.com/gravitee-io/issues/issues/8839[#8839]
+
+=== Portal
+
+* Properly display buttons in application analytics filters https://github.com/gravitee-io/issues/issues/8677[#8677]
+ 
 == APIM - 3.19.6 (2023-01-05)
 
 === API


### PR DESCRIPTION

# New APIM version 3.19.7 has been released
📝 You can modify the changelog template online [here](https://github.com/gravitee-io/gravitee-docs/edit/release-apim-3.19.7/pages/apim/3.x/changelog/changelog-3.19.adoc)

Here is some information to help with the writing:

## Pull requests
<details>
  <summary>See all Pull Requests</summary>

### [bump swagger version [3021]](https://github.com/gravitee-io/gravitee-api-management/pull/3021)
- fix: validation messages are never displayed
### [bump swagger version [3021]](https://github.com/gravitee-io/gravitee-api-management/pull/3021)
- fix: bump swagger version
### [Do not save clientId in APIKEY subscription [3020]](https://github.com/gravitee-io/gravitee-api-management/pull/3020)
- fix: do not save clientId in APIKEY subscription
### [fix: add search to log filters to improve performances [3013]](https://github.com/gravitee-io/gravitee-api-management/pull/3013)
- fix: add search to log filters to improve performances
### [Display icons of APIs in API list screen [3012]](https://github.com/gravitee-io/gravitee-api-management/pull/3012)
- fix: display icons of APIs in API list screen
### [API key synchronization gives precedence to active keys [3004]](https://github.com/gravitee-io/gravitee-api-management/pull/3004)
- fix: API key synchronization gives precedence to active keys
### [fix: bump data-logging-masking policy for dev env to 2.0.3 [2994]](https://github.com/gravitee-io/gravitee-api-management/pull/2994)
- fix: bump data-logging-masking policy for dev env to 2.0.3
### [Fix error message displayed when trying to publish 2 keyless plans [2984]](https://github.com/gravitee-io/gravitee-api-management/pull/2984)
- fix: fix error message displayed when trying to publish 2 keyless plan
### [Update flows condition max size to 512 [2982]](https://github.com/gravitee-io/gravitee-api-management/pull/2982)
- fix(jdbc): update flows condition max size to 512
### [feat: websocket frame compression support [2967]](https://github.com/gravitee-io/gravitee-api-management/pull/2967)
- feat: websocket frame compression support
### [Merge 3.15.22 into 3.18.x [2966]](https://github.com/gravitee-io/gravitee-api-management/pull/2966)
- fix(cockpit): make hello command reply update only organization
### [fix(cockpit): make hello command reply update only organization [2931]](https://github.com/gravitee-io/gravitee-api-management/pull/2931)
- fix(cockpit): make hello command reply update only organization
### [fix: email notifier 1.5.0 with authMethods downgraded in 3.18.x [2946]](https://github.com/gravitee-io/gravitee-api-management/pull/2946)
- fix: email notifier 1.5.0 with authMethods downgraded in 3.18.x
### [fix spring circular dependencies at startup [2937]](https://github.com/gravitee-io/gravitee-api-management/pull/2937)
- fix: add @Lazy to avoid circular dependencies
### [fix: resolve deployment of an api with group as primary owner [2932]](https://github.com/gravitee-io/gravitee-api-management/pull/2932)
- fix: resolve deployment of an api with group as primary owner
### [Fix Liquibase script's error on upgrade [2927]](https://github.com/gravitee-io/gravitee-api-management/pull/2927)
- fix(repository): change PK of flow_steps table to a new auto incremented column
### [fix: keep plan policies during migration [2916]](https://github.com/gravitee-io/gravitee-api-management/pull/2916)
- fix: keep plan policies during migration
### [fix(jdbc): change flows condition max size [2918]](https://github.com/gravitee-io/gravitee-api-management/pull/2918)
- fix(jdbc): change flows condition max size
### [Fix Liquibase script's error on upgrade #2910 [2924]](https://github.com/gravitee-io/gravitee-api-management/pull/2924)
- fix(repository): change PK of flow_steps table to a new auto incremented column
### [fix: API key synchronization gives precedence to active keys [2905]](https://github.com/gravitee-io/gravitee-api-management/pull/2905)
- fix: API key synchronization gives precedence to active keys

</details>

## Jira issues

[See all Jira issues for 3.19.x version](https://gravitee.atlassian.net/jira/software/c/projects/APIM/issues/?jql=project%20%3D%20%22APIM%22%20and%20fixVersion%20%3D%203.19.7%20and%20status%20%3D%20Done%20ORDER%20BY%20created%20DESC)
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://graviteedocs.blob.core.windows.net/release-apim-3-19-7/index.html)
<!-- UI placeholder end -->
