### PR TITLE
fix(rest-api): return 401 when no Auth header at login

### DIFF
--- a/pages/apim/3.x/installation-guide/installation-guide-migration.adoc
+++ b/pages/apim/3.x/installation-guide/installation-guide-migration.adoc
@@ -13,6 +13,8 @@ You may be required to perform manual actions as part of the upgrade.
 WARNING: Be sure to run scripts on the correct database since `gravitee` is not always the default database!
 Check your db name by running `show dbs;`
 
+include::upgrades/3.21.0/README.adoc[leveloffset=+1]
+
 include::upgrades/3.20.0/README.adoc[leveloffset=+1]
 
 include::upgrades/3.19.5/README.adoc[leveloffset=+1]

--- a/pages/apim/3.x/installation-guide/upgrades/3.21.0/README.adoc
+++ b/pages/apim/3.x/installation-guide/upgrades/3.21.0/README.adoc
@@ -1,0 +1,8 @@
+= Upgrade to 3.21.0
+
+== Breaking changes
+
+=== Management API
+In previous versions, sending a POST request to /user/login without an Authorization returned HTTP Response 200.
+
+Starting with 3.21.0, if a POST request to /user/login does not have an Authorization header, it will receive a HTTP response 401 - Unauthorized.


### PR DESCRIPTION
**Issue**

https://github.com/gravitee-io/issues/issues/8862
https://gravitee.atlassian.net/browse/APIM-726

**Description**

Add documentation for fix: when user sends POST request to /user/login without Auth --> return HTTP response 401

**Screenshots**

<!-- If applicable, add screenshots to help explain your problem. -->

**Additional context**

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->

<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://graviteedocs.blob.core.windows.net/apim-726-fix-no-auth-return-200/index.html)
<!-- UI placeholder end -->
