### PR TITLE
[APIM] Add changelog for new 3.20.1 release

### DIFF
--- a/pages/apim/3.x/changelog/changelog-3.20.adoc
+++ b/pages/apim/3.x/changelog/changelog-3.20.adoc
@@ -12,6 +12,46 @@ For upgrade instructions, please refer to https://docs.gravitee.io/apim/3.x/apim
 // NOTE: Global 3.20 release info here
 
 // <DO NOT REMOVE THIS COMMENT - ANCHOR FOR FUTURE RELEASES>
+ 
+== APIM - 3.20.1 (2023-02-10)
+
+
+=== API
+
+* Sanitize some fields of new External User, Application, Plan https://github.com/gravitee-io/issues/issues/7560[#7560] & https://github.com/gravitee-io/issues/issues/8847[#8847]
+
+* Plan policies were lost when migrated from an API to design studio https://github.com/gravitee-io/issues/issues/8632[#8632]
+* Bump Email Notifier to `1.5.0` https://github.com/gravitee-io/issues/issues/8830[#8830]
+* Update flows condition max size to 512 https://github.com/gravitee-io/issues/issues/8823[#8823] & https://github.com/gravitee-io/issues/issues/8671[#8671]
+* Duplicated platform flows when APIM is linked to Cockpit https://github.com/gravitee-io/issues/issues/8832[#8832]
+* Unable to start up with JDBC when platform flows have been defined with multiple steps on the same phase https://github.com/gravitee-io/issues/issues/8816[#8816]
+* Handle YAML Anchors and Alias when importing OpenAPI file https://github.com/gravitee-io/issues/issues/8858[#8858]
+
+=== Gateway
+
+* Make sure websocket is closed in any cases https://github.com/gravitee-io/gravitee-api-management/pull/2796[#2796]
+* EL was not working properly for the assign attribute policy depending on the scope of execution https://github.com/gravitee-io/issues/issues/8810[#8810]
+* Subscription lost when redeploying https://github.com/gravitee-io/issues/issues/8855[#8855]
+
+* API Subscription was not working after closing and re-creating https://github.com/gravitee-io/issues/issues/8600[#8600]
+* Add support from websocket frame compression https://github.com/gravitee-io/issues/issues/8689[#8689]
+* Exception "Error while determining deployed APIs store into events payload" fixed https://github.com/gravitee-io/issues/issues/8464[#8464]
+* Do not save clientId in API key subscription https://github.com/gravitee-io/issues/issues/8855[#8855]
+* Properly set `response` attribute in the execution context for the `assign-attribute` policy https://github.com/gravitee-io/issues/issues/8810[#8810]
+
+=== Console
+
+* "Show advanced filters" was missing on the analytics page https://github.com/gravitee-io/issues/issues/8677[#8677]
+* Version column renamed on API table. https://github.com/gravitee-io/issues/issues/8772[#8772]
+* Improved API names loading in the Platform Analytics Dashboard https://github.com/gravitee-io/issues/issues/8839[#8839] & https://github.com/gravitee-io/issues/issues/8822[#8822]
+
+* Display icons of APIs in API list screen https://github.com/gravitee-io/issues/issues/8809[#8809]
+* Global improvement on log filters https://github.com/gravitee-io/issues/issues/8822[#8822] & https://github.com/gravitee-io/issues/issues/8839[#8839]
+
+=== Portal
+
+* Properly display buttons in application analytics filters https://github.com/gravitee-io/issues/issues/8677[#8677]
+
 
 == APIM - 3.20 (2023-01-05)
 


### PR DESCRIPTION
# New APIM version 3.20.1 has been released
📝 You can modify the changelog template online [here](https://github.com/gravitee-io/gravitee-docs/edit/release-apim-3.20.1/pages/apim/3.x/changelog/changelog-3.20.adoc)

Here is some information to help with the writing:

## Pull requests
<details>
  <summary>See all Pull Requests</summary>
  
### [Sanitize some fields of new ExternalUser, Application, Plan - 3.19.x (backport #3038) [3039]](https://github.com/gravitee-io/gravitee-api-management/pull/3039)
- fix: sanitize name of new API
- fix: sanitize name and description of new Plan
- fix: sanitize name and description of new Application
- fix: sanitize firstname and lastname of NewExternalUserEntity
### [Sanitize some fields of new ExternalUser, Application, Plan - 3.19.x [3038]](https://github.com/gravitee-io/gravitee-api-management/pull/3038)
- fix: sanitize name of new API
- fix: sanitize name and description of new Plan
- fix: sanitize name and description of new Application
- fix: sanitize firstname and lastname of NewExternalUserEntity
### [Update headers in API list screen  [2981]](https://github.com/gravitee-io/gravitee-api-management/pull/2981)
- fix: update headers in API list screen
### [Fix Liquibase script's error on upgrade [2910]](https://github.com/gravitee-io/gravitee-api-management/pull/2910)
- fix(repository): change PK of flow_steps table to a new auto incremented column
### [Merge 3.20.x into master [2898]](https://github.com/gravitee-io/gravitee-api-management/pull/2898)
- fix(console): remove second scroll in gw instance details page
- fix(console): make menu environment selector work
- fix(console): re add ApiPortalController for groups page
- fix(console): add tabs menu for gravitee v1.0.0 design page
- fix: keep overrideEntrypoint value during sanitization
- fix(console): use ng-prop for gv-icon binding
- fix: SubscriptionResponse should handle body operations
- fix: check if api requires a deployment before redeploying every objects related
- fix: v4 platform flow timeout
- fix: flaky test on http-proxy connector
- fix: properly clean previous deployed acceptors
### [fix(console): avoid horizontal scroll on logs page [2864]](https://github.com/gravitee-io/gravitee-api-management/pull/2864)
- fix(console): avoid horizontal scroll on logs page
### [3.20.x fix bootstrap [2863]](https://github.com/gravitee-io/gravitee-api-management/pull/2863)
- fix(console): make bootstrap work when $state are not resolve
### [Fix virtual host screen [2854]](https://github.com/gravitee-io/gravitee-api-management/pull/2854)
- fix(console): fix host validation
- fix: force virtualhost if domain restrictions
### [fix(console): properly display user avatar in top bar user menu [2853]](https://github.com/gravitee-io/gravitee-api-management/pull/2853)
- fix(console): properly display user avatar in top bar user menu
### [fix(console): load icon only if has shape [2851]](https://github.com/gravitee-io/gravitee-api-management/pull/2851)
- fix(console): load icon only if has shape
### [fix(console): improve overlay menu position [2849]](https://github.com/gravitee-io/gravitee-api-management/pull/2849)
- fix(console): improve overlay menu position
### [fix(console): fix time range picker in alerts [2846]](https://github.com/gravitee-io/gravitee-api-management/pull/2846)
- fix(console): fix time range picker in alerts
### [Fix API synchronizer to undeploy API with wrong tags [2844]](https://github.com/gravitee-io/gravitee-api-management/pull/2844)
- fix(gateway): APISynchronizer can now undeploy API with wrong tags
### [fix: remove Highchart export module [2845]](https://github.com/gravitee-io/gravitee-api-management/pull/2845)
- fix: remove Highchart export module
### [feat(console): add help banner to submenu [2843]](https://github.com/gravitee-io/gravitee-api-management/pull/2843)
- feat(console): add help banner to submenu
### [403 api creation [2831]](https://github.com/gravitee-io/gravitee-api-management/pull/2831)
- fix(console): put api cretion actions always at the bottom of the page
- fix(console): improve timeline rendering in api creation
### [fix(console): fix submenu position in collapsed mode [2838]](https://github.com/gravitee-io/gravitee-api-management/pull/2838)
- fix(console): fix submenu position in collapsed mode
### [fix(console): fix time range picker in alerts [2824]](https://github.com/gravitee-io/gravitee-api-management/pull/2824)
- fix(console): fix time range picker in alerts
### [fix: ensure etag is updated in api creation wizzard [2823]](https://github.com/gravitee-io/gravitee-api-management/pull/2823)
- fix: ensure etag is updated in api creation wizzard
### [405 design improvements [2812]](https://github.com/gravitee-io/gravitee-api-management/pull/2812)
- feat(console): improve design of api proxy health-check
- feat(console): improve design of export dialog
### [fix(console): resolve click on show-secret on resource conf [2815]](https://github.com/gravitee-io/gravitee-api-management/pull/2815)
- fix(console): resolve click on show-secret on resource conf
### [fix: load bootstrap on legacy angularJS pages [2821]](https://github.com/gravitee-io/gravitee-api-management/pull/2821)
- fix: load bootstrap on legacy angularJS pages
### [fix: set minimum values to rate limit inputs in api wizard [2819]](https://github.com/gravitee-io/gravitee-api-management/pull/2819)
- fix: set minimum values to rate limit inputs in api wizard
### [fix: avoid hint and input overlap in stepper [2816]](https://github.com/gravitee-io/gravitee-api-management/pull/2816)
- fix: avoid hint and input overlap in stepper
### [UAT - highlight the user avatar only and not the background [2805]](https://github.com/gravitee-io/gravitee-api-management/pull/2805)
- fix: highlight the user avatar only and not the background
### [fix: use right field to configure a confirm dialog [2806]](https://github.com/gravitee-io/gravitee-api-management/pull/2806)
- fix: use right field to configure a confirm dialog
### [UAT -  use same icons & tooltips for API list and detail [2804]](https://github.com/gravitee-io/gravitee-api-management/pull/2804)
- fix: realign APIs status icons and tooltip
### [UAT - show alert only if alert service is enabled [2803]](https://github.com/gravitee-io/gravitee-api-management/pull/2803)
- fix: show alert only if alert service is enabled
### [UAT - Share the api etag value across angularJS and angular. [2797]](https://github.com/gravitee-io/gravitee-api-management/pull/2797)
- fix: share the api etag value across angularJS and angular
### [UAT - Init endpoint list in creation mode [2799]](https://github.com/gravitee-io/gravitee-api-management/pull/2799)
- fix: init endpoint list in creation mode
### [fix(console): fix debug mode height [2798]](https://github.com/gravitee-io/gravitee-api-management/pull/2798)
- fix(console): fix debug mode height
### [fix(console): fix tooltip background color [2800]](https://github.com/gravitee-io/gravitee-api-management/pull/2800)
- fix(console): fix tooltip background color
### [fix(console): open documentation link to new tab [2801]](https://github.com/gravitee-io/gravitee-api-management/pull/2801)
- fix(console): open documentation link to new tab
### [fix: make sure websocket is closed in any cases [2796]](https://github.com/gravitee-io/gravitee-api-management/pull/2796)
- fix: make sure websocket is closed in any cases
### [UAT - Format the notification creation date to be readable [2795]](https://github.com/gravitee-io/gravitee-api-management/pull/2795)
- fix: format `createdAt` field of the notification
### [UAT - Init endpoint variable when no other exists [2791]](https://github.com/gravitee-io/gravitee-api-management/pull/2791)
- fix: init endpoint variable when no other exists
### [UAT - v3 planEntity should use v3 enum for type  [2793]](https://github.com/gravitee-io/gravitee-api-management/pull/2793)
- fix: v3 planEntity should use v3 enum for type
### [Fix template providers [2787]](https://github.com/gravitee-io/gravitee-api-management/pull/2787)
- fix: do not change subscription attributes while security is skipped
- fix: copy template providers to ctx instead of referring to the reactor list
- fix: instantiate new ctx on each retry
### [fix-missing-qos-requirement-websocket [2783]](https://github.com/gravitee-io/gravitee-api-management/pull/2783)
- fix: build missing qos requirement for ws
### [Fix/fix subscriptions without configuration run e2e [2743]](https://github.com/gravitee-io/gravitee-api-management/pull/2743)
- fix: subscription validation accepts subscriptions without configuration
### [fix(console): resolve user notification menu [2742]](https://github.com/gravitee-io/gravitee-api-management/pull/2742)
- fix(console): resolve user notification menu
### [Apim 141/manage v4subscriptions [2659]](https://github.com/gravitee-io/gravitee-api-management/pull/2659)
- feat: manage v4 subscription consumer
### [feat(console): add v1 migration banner [2737]](https://github.com/gravitee-io/gravitee-api-management/pull/2737)
- feat(console): add v1 migration banner
### [[Console] Migration plan - Part 2 [2730]](https://github.com/gravitee-io/gravitee-api-management/pull/2730)
- fix(console): fix ToC scrollingContainer
- fix(console): link <form> to reactive form to avoid native html behaviour on it
- feat(console): impl error handler for secure step in plan page
- feat(console): impl secure step in plan page
- fix(console): remove padding bottom on search input
- fix(console): ui/ux feedback
- feat(console): improve layout responsive-margin-container
### [feat: delete api media [2719]](https://github.com/gravitee-io/gravitee-api-management/pull/2719)
- feat: add endpoint to delete media by hash and api
### [feat: reduce subscriptions and API keys incremental refresh timeframe [2739]](https://github.com/gravitee-io/gravitee-api-management/pull/2739)
- feat: reduce subscriptions and API keys incremental refresh timeframe
### [fix: issue pom version [2738]](https://github.com/gravitee-io/gravitee-api-management/pull/2738)
- fix: issue pom version
### [fix: issue with key less plan [2736]](https://github.com/gravitee-io/gravitee-api-management/pull/2736)
- fix: issue with key less plan
### [refactor: change how qos is managed [2709]](https://github.com/gravitee-io/gravitee-api-management/pull/2709)
- feat: improve how qos is managed
### [APIM-161 Properly manage mqtt clients across multiples requests  [2697]](https://github.com/gravitee-io/gravitee-api-management/pull/2697)
- feat: properly handle mqtt5 clients across multiple requests
### [feat(console): add definition version to api list [2728]](https://github.com/gravitee-io/gravitee-api-management/pull/2728)
- feat(console): add definition version to api list
### [feat(console): migrate plans page [2717]](https://github.com/gravitee-io/gravitee-api-management/pull/2717)
- feat(console): remove drag icon for plan pushed with kubernetes
- feat(console): order plans on drop
- feat(console): add new plan
- feat(console): close plan
- feat(console): deprecate plan
- feat(console): publish plan
- feat(console): add navigation actions
- feat(console): add drag and drop
- feat(console): filter on plan status
- feat(console): add plan simple table
- feat(console): init api plans migration
### [fix(console): resolve login page background [2691]](https://github.com/gravitee-io/gravitee-api-management/pull/2691)
- fix(console): resolve login page background
### [fix v4 http proxy headers and plans [2724]](https://github.com/gravitee-io/gravitee-api-management/pull/2724)
- fix: fix security plan for v4 definition
- fix: propagate endpoint response headers
### [Change top bar [2718]](https://github.com/gravitee-io/gravitee-api-management/pull/2718)
- fix(console): fix layout with new topbar
- fix: set height to .gio-main-page
- feat: add new notification menu
- feat: add new user menu
- feat: add new top-bar
### [[Console] Migrate plan - part 2 [2721]](https://github.com/gravitee-io/gravitee-api-management/pull/2721)
- feat(console): disable shading tags when needed in plan form
- feat(console): impl generalConditions select in plan form
- feat(console): init plan general step form inputs
- fix(console): use textarea instead input for api details page
- fix(console): set creationMode input for gio-save-bar
- fix(console): set right aria-label
- feat(console): init empty PlanEdit step component
### [APIM-338 fix: handle acceptor by type [2710]](https://github.com/gravitee-io/gravitee-api-management/pull/2710)
- fix: handle acceptor by type
### [fix: host header propagation for http1.1 and http2 [2720]](https://github.com/gravitee-io/gravitee-api-management/pull/2720)
- fix: host header propagation for http1.1 and http2
### [APIM-307 Allow to use subscription details on EL [2700]](https://github.com/gravitee-io/gravitee-api-management/pull/2700)
- feat: allow access resolved subscription from a EL
### [[Console] Plan migration - Part 0 [2716]](https://github.com/gravitee-io/gravitee-api-management/pull/2716)
- feat(console): init empty ApiPortalPlanEdit component
- fix(console): support multiple baseRoute to active menu link
- fix(console): health-check add readonly for k8s api
### [fix: handle a graceful shutdown [2715]](https://github.com/gravitee-io/gravitee-api-management/pull/2715)
- fix: handle a graceful shutdown
### [[Console] Fix console layout [2707]](https://github.com/gravitee-io/gravitee-api-management/pull/2707)
- fix(console): check menu on each location change
- fix(console): fix table of content scroll event watch
- fix(console): fix layout on all console
### [Apim 127 health check part2 [2699]](https://github.com/gravitee-io/gravitee-api-management/pull/2699)
- fix(console): endpoint group loadBalancerType mapping
- fix(console): on endpoint save keep on same page with updated name
- fix(console): use only layout for main endpoint group page
- feat(console): separate health-check Dashboard in dedicated page
### [feat: http-proxy entrypoint and endpoint connectors [2685]](https://github.com/gravitee-io/gravitee-api-management/pull/2685)
- feat: http-proxy entrypoint and endpoint connectors
### [feat: update icons [2682]](https://github.com/gravitee-io/gravitee-api-management/pull/2682)
- feat: update icons
### [(Console): Migrate health check Part 1 [2698]](https://github.com/gravitee-io/gravitee-api-management/pull/2698)
- fix(console): not redirect to list on save endpoint config
- feat(console): impl Health Check whin inherit mode for endpoints config
- fix(console): remove bad aria-label property
- feat(console): use Health Check in global Configuration
- feat(console): impl Health Check whin initial value
- fix(console): wrap endpoint into form with `gioFormFocusInvalid` directive
- feat(console): impl Health Check with Assertions part
- feat(console): impl Health Check with Trigger & Request part
- fix(console): use scss page layout only for parent page component
- fix(console): try to get `disabled` state updated from inner MatSlideToggle
### [APIM-200 Implement mqtt5 security capabilities [2684]](https://github.com/gravitee-io/gravitee-api-management/pull/2684)
- fix: make client identifier unique to avoid collision
- feat: implement security feature for MQTT Advanced
- fix: kafka exception handling on authentication exception
### [fix: issue when one kafka sub connections got closed [2687]](https://github.com/gravitee-io/gravitee-api-management/pull/2687)
- fix: test if there is any current active connection while checking close ones
### [fix: add validation on webhook's callbackUrl configuration [2683]](https://github.com/gravitee-io/gravitee-api-management/pull/2683)
- fix: add validation on webhook's callbackUrl configuration - callbackUrl can not be an empty string - it should be a valid http(s) url
### [fix: merge dematerialized flux to get a completed merge flux [2686]](https://github.com/gravitee-io/gravitee-api-management/pull/2686)
- fix: merge dematerialized flux to get a completed merge flux
### [fix: kafka exception handling on authentication exception [2681]](https://github.com/gravitee-io/gravitee-api-management/pull/2681)
- fix: kafka exception handling on authentication exception
### [Replace old instance detail component with angular  [2680]](https://github.com/gravitee-io/gravitee-api-management/pull/2680)
- feat: replace old instance detail component with angular
### [fix: UI feedbacks [2679]](https://github.com/gravitee-io/gravitee-api-management/pull/2679)
- fix: UI feedbacks
### [[console] gateway page improvement [2677]](https://github.com/gravitee-io/gravitee-api-management/pull/2677)
- feat: remove submenu from new pages
- feat: migrate instance header to angular
- fix: align data for CPU load-average
### [[Console] finish api proxy failover migration [2675]](https://github.com/gravitee-io/gravitee-api-management/pull/2675)
- feat(console): finish api proxy `failover` migration
### [feat: implement background mechanism to check kafka connectivity [2640]](https://github.com/gravitee-io/gravitee-api-management/pull/2640)
- feat: implement background mechanism to check kafka connectivity
### [fix(menu): apply feedback [2673]](https://github.com/gravitee-io/gravitee-api-management/pull/2673)
- fix(menu): apply feedback
### [fix:instance monitoring [2672]](https://github.com/gravitee-io/gravitee-api-management/pull/2672)
- fix:instance monitoring
### [Migrate Gateway instance environment screen to Angular [2663]](https://github.com/gravitee-io/gravitee-api-management/pull/2663)
- feat: migrate instance-environment screen
### [[Console] Small fix for api list & virtual host [2671]](https://github.com/gravitee-io/gravitee-api-management/pull/2671)
- fix(console): display api avatar into api-list if filled
- fix(console): hide virtual-host add & remove button
### [fix(console): improve api portal details with last UI/UX feedback [2669]](https://github.com/gravitee-io/gravitee-api-management/pull/2669)
- fix(console): improve api portal details with last UI/UX feedback
### [feat(menu): implement keyboard nav [2665]](https://github.com/gravitee-io/gravitee-api-management/pull/2665)
- feat(menu): implement keyboard nav
### [feat(console): use new api details page & remove legacy one [2653]](https://github.com/gravitee-io/gravitee-api-management/pull/2653)
- fix(console): fix layout with angular page
- feat(console): use new api details page & remove legacy one
### [APIM-162 first implementation of mqtt5 endpoint [2662]](https://github.com/gravitee-io/gravitee-api-management/pull/2662)
- feat: first implementation of mqtt5 endpoint
### [Migrate Gateway instance monitoring screen to Angular [2657]](https://github.com/gravitee-io/gravitee-api-management/pull/2657)
- feat: migrate instance-monitoring screen
- feat: create new service for instance management
### [fix(console): use material by default, apply bootstrap only if necessary [2660]](https://github.com/gravitee-io/gravitee-api-management/pull/2660)
- fix(console): use material by default, apply bootstrap only if necessary
### [feat(menu): improve reduced mode [2648]](https://github.com/gravitee-io/gravitee-api-management/pull/2648)
- feat(menu): improve reduced mode
### [[master] handle huge payload from cockpit controller  [2658]](https://github.com/gravitee-io/gravitee-api-management/pull/2658)
- fix: handle huge payload from cockpit controller
### [[Console] Migration for api portal details [2647]](https://github.com/gravitee-io/gravitee-api-management/pull/2647)
- fix(console): display k8s icon for k8s origin API
- feat(console): add readonly for k8s api in api portal details page
- fix: always try to get cockpit url from backend
- feat(console): migrate API creation import
- feat(console): support api v1.0.0 in migrated portal details page
### [feat: enhance API crd export [2633]](https://github.com/gravitee-io/gravitee-api-management/pull/2633)
- feat: add option to remove ids on api crd export
### [[Console] Migrate portal details screen - Part 4 [2635]](https://github.com/gravitee-io/gravitee-api-management/pull/2635)
- feat(console): impl promote API in portal details component
- feat(console): considers feedback from the UI/UX team
- feat(console): impl export API in portal details component
- feat(console): impl duplicate API in portal details component
- feat(console): impl import API in portal details component
### [feat(menu): use new component for first and second level menu [2606]](https://github.com/gravitee-io/gravitee-api-management/pull/2606)
- feat: remove old sidenav
- feat(submenu): add new component for Gateway navigation
- feat(submenu): add new component for API navigation
- feat(submenu): add new component for Application navigation
- feat(submenu): add new component for Settings navigation
- feat(menu): use new component for first level menu
### [feat: webhook entrypoint considers headers from response [2632]](https://github.com/gravitee-io/gravitee-api-management/pull/2632)
- feat: webhook entrypoint considers headers from response
### [fix: check webhook entrypoint configuration header name format [2631]](https://github.com/gravitee-io/gravitee-api-management/pull/2631)
- fix: check webhook entrypoint configuration header name format
### [APIM-182 properly handle kafka clients creation [2620]](https://github.com/gravitee-io/gravitee-api-management/pull/2620)
- feat: add local cache to avoid recreating many times kafka producer/consumers
- feat: add local cache to avoid recreating many times kafka producer/consumers
- feat: add life cycle management for endpoint
### [fix: add support for metadata in crd export [2623]](https://github.com/gravitee-io/gravitee-api-management/pull/2623)
- fix: add support for metadata in crd export
### [fix(test-sdk): downgrade jetty server for wiremock [2622]](https://github.com/gravitee-io/gravitee-api-management/pull/2622)
- fix(test-sdk): downgrade jetty server for wiremock
### [[console] Migrate api details import modal [2615]](https://github.com/gravitee-io/gravitee-api-management/pull/2615)
- feat(console): impl delete API in portal details component
- feat(console): create api-import-dialog - Part 3
- feat(console): create api-import-dialog - Part 2
- feat(console): create api-import-dialog - Part 1
### [feat: validate subscription configuration [2621]](https://github.com/gravitee-io/gravitee-api-management/pull/2621)
- feat: validate subscription configuration
- fix: rename entrypoint checking method
### [Apim 65/api with webhook [2608]](https://github.com/gravitee-io/gravitee-api-management/pull/2608)
- fix: fix entrypoint websocket schemas folder
- feat: use ConnectorHelper to get entrypoint subscription configuration
- feat: handle webhook entrypoint headers configuration
- feat: handle webhook entrypoint configuration at subscription level
- feat: get subscription schema form for entrypoint plugin
### [fix: ignore message level policy for v2 platform flows [2619]](https://github.com/gravitee-io/gravitee-api-management/pull/2619)
- fix: ignore message level policy for v2 platform flows
### [fix: interrupt http-post when redeploying api [2617]](https://github.com/gravitee-io/gravitee-api-management/pull/2617)
- fix: interrupt http-post when redeploying api
### [fix: npe on message condition [2613]](https://github.com/gravitee-io/gravitee-api-management/pull/2613)
- fix: npe on message condition
### [feat(console): api proxy endpoints groups [2578]](https://github.com/gravitee-io/gravitee-api-management/pull/2578)
- feat(console): make api proxy endpoint readonly
- feat(console): create new endpoint
- feat(console): edit endpoint configuration
- feat(console): init general form for endpoint configuration
- feat(console): init api proxy group endpoint components
- fix: hide add group button for kubernetes apis in proxy page
- feat(console): manage gv-schema-form reset for api proxy groups
- feat(console): add uniqueness check on name
- feat(console): add read only for kubernetes apis
- feat(console): add new api proxy endpoint group
- feat(console): edit existing api proxy group service discovery configuration
- feat(console): edit existing api proxy group configuration
- feat(console): edit existing api proxy group general info
- feat(console): init proxy group components migration
### [Feat/#125 edit proxy failover [2601]](https://github.com/gravitee-io/gravitee-api-management/pull/2601)
- feat(console): migrate api proxy failover page
### [fix: import kubernetes managed api with state [2602]](https://github.com/gravitee-io/gravitee-api-management/pull/2602)
- fix: import kubernetes managed api with state
### [fix(liquibase): bump liquibase version to latest [2556]](https://github.com/gravitee-io/gravitee-api-management/pull/2556)
- fix(liquibase): bump liquibase version to latest
### [APIM-60: add security support on kafka endpoint [2590]](https://github.com/gravitee-io/gravitee-api-management/pull/2590)
- feat: update kafka endpoint to allow security feature
### [[Console] Migrate api details - Part 2/♾ [2570]](https://github.com/gravitee-io/gravitee-api-management/pull/2570)
- feat: improve portal detail file picker use
- feat(console): impl quality in portal details component
- feat(console): impl enableJupiter in portal details component
- feat(console): impl changeVisibility in portal details component
- feat(console): impl changeApiLifecycle in portal details component
- feat(console): impl changeLifecycle in portal details component
- feat(console): impl askForReview in portal details component
- feat(console):add interceptor to set if-match with last etag for some resources
### [feat: improve the way http-get handle ACCEPT header [2565]](https://github.com/gravitee-io/gravitee-api-management/pull/2565)
- fix: improve lastId handling in mock endpoint mock endpoint handled lastId but continued to send as many message as configured for messagesLimitCount https://graviteecommunity.atlassian.net/browse/APIM-97
- feat: improve the way http-get handle ACCEPT header - parse all the values related to ACCEPT header and sort them by quality to select the best one. - improvement of specific cases: null or empty ACCEPT header will fall back to text/plain and */* ACCEPT header will fall back to application/json https://graviteecommunity.atlassian.net/browse/APIM-97
### [fix: downgrade rxJava, due to reactor-addons incompatibility [2584]](https://github.com/gravitee-io/gravitee-api-management/pull/2584)
- fix: downgrade rxJava, due to reactor-addons incompatibility
### [Qos [2522]](https://github.com/gravitee-io/gravitee-api-management/pull/2522)
- feat: implement QoS for event-native
### [feat: add support for condition at message level [2569]](https://github.com/gravitee-io/gravitee-api-management/pull/2569)
- feat: add support for condition at message level
### [feat: remove old entrypoint page [2563]](https://github.com/gravitee-io/gravitee-api-management/pull/2563)
- feat: remove old entrypoint page
### [feat: improve image upload errors displayed the user [2560]](https://github.com/gravitee-io/gravitee-api-management/pull/2560)
- feat: improve image upload errors displayed the user
### [APIM-98 add method to easily interrupt body or message flow [2557]](https://github.com/gravitee-io/gravitee-api-management/pull/2557)
- fix: allow interrupting body or messages flow
- fix: check if throwable message is not null otherwise use empty buffer
### [[console] Start migration of Api portal details screen [2520]](https://github.com/gravitee-io/gravitee-api-management/pull/2520)
- feat(console): impl dumb button portal details component
- feat(console): impl api info in portal details component
- feat(console): impl categories input form in portal details component
- feat(console): impl labels input form in portal details component
- feat(console): impl image picker form in portal detailis component
- feat(console): impl part of portal details form
- feat(console): init empty ApiPortalDetails Component
### [[Snyk] Fix for 3 vulnerabilities [2533]](https://github.com/gravitee-io/gravitee-api-management/pull/2533)
- fix: pom.xml to reduce vulnerabilities
### [fix(jupiter): support large body POST with backpressure [2541]](https://github.com/gravitee-io/gravitee-api-management/pull/2541)
- fix(jupiter): support large body POST with backpressure
### [fix(design-studio): display available resources again [2546]](https://github.com/gravitee-io/gravitee-api-management/pull/2546)
- fix(design-studio): display available resources again
### [feat: list api enpoints [2540]](https://github.com/gravitee-io/gravitee-api-management/pull/2540)
- feat: move secondary badge into icons column
- feat: display deploy API banner on update
- feat: handle read only actions icons for kubernetes apis
- feat: display inherit icon for http configuration
- feat: delete endpoint in a group
- feat: delete endpoint groups
- feat: add health check and secondy endpoint
- feat: list endpoints
- feat: add api proxy endpoint list component
### [feat: remove old api proxy deployments page [2544]](https://github.com/gravitee-io/gravitee-api-management/pull/2544)
- feat: remove old api proxy deployments page
### [feat: remove old api proxy cors page [2543]](https://github.com/gravitee-io/gravitee-api-management/pull/2543)
- feat: remove old api proxy cors page
### [feat: migrate response template pages [2523]](https://github.com/gravitee-io/gravitee-api-management/pull/2523)
- feat(console): avoid screen blinking on response template list page loading
- feat(console): redirect edit and create response template on new pages
- feat(console): redirect on new response template view
- feat(console): remove response template body column
### [feat: handle stop on entrypoint connector [2525]](https://github.com/gravitee-io/gravitee-api-management/pull/2525)
- feat: handle stop on entrypoint connector
### [fix(ui): remove relative base href [2508]](https://github.com/gravitee-io/gravitee-api-management/pull/2508)
- fix(ui): remove relative base href
### [Properly handle error when processing async api [2419]](https://github.com/gravitee-io/gravitee-api-management/pull/2419)
- feat(v4): handle error message for entrypoints
- feat(): add message processor chain
- feat(): add processor and error on async api
- feat: apply policies on messages for async subscription api
- feat: apply policies on messages for async api
### [feat(console): mode readonly when api origin is kubernetes [2480]](https://github.com/gravitee-io/gravitee-api-management/pull/2480)
- feat(console): mode readonly when api origin is kubernetes
### [feat(sse): handle Last-Event-ID header [2507]](https://github.com/gravitee-io/gravitee-api-management/pull/2507)
- feat(sse): handle Last-Event-ID header
### [[Snyk] Security upgrade org.apache.xmlgraphics:batik-transcoder from 1.14 to 1.15 [2505]](https://github.com/gravitee-io/gravitee-api-management/pull/2505)
- fix: pom.xml to reduce vulnerabilities
### [Add flow resolution selectors [2488]](https://github.com/gravitee-io/gravitee-api-management/pull/2488)
- feat(v4): add condition filter for flow selectors
- feat(v4): add entrypoints filter on channel selector
### [feat(entrypoint): add a new http-get entrypoint [2394]](https://github.com/gravitee-io/gravitee-api-management/pull/2394)
- fix: regenerate e2e tests sdk
- feat(entrypoint): add a new http-get entrypoint
- feat(mock-endpoint): implement LIMIT and RESUME features
- feat: add "feature" notion on connectors
### [feat(sse): implement heartbeat mechanism for SSE [2479]](https://github.com/gravitee-io/gravitee-api-management/pull/2479)
- feat(sse): implement heartbeat mechanism for SSE
### [generate APIM e2e tests sdk on each PR and fails if uncommited changes [2476]](https://github.com/gravitee-io/gravitee-api-management/pull/2476)
- fix: fix EntrypointResource path parameter name
### [feat(sme): implement websocket entrypoint [2471]](https://github.com/gravitee-io/gravitee-api-management/pull/2471)
- feat(sme): implement websocket entrypoint
### [[Console] Migrate proxy response templates [2466]](https://github.com/gravitee-io/gravitee-api-management/pull/2466)
- feat(console): mode readonly when api origin is kubernetes
- feat(console): impl delete with dialog for ApiProxyResponseTemplates
- feat(console): add go back button in ApiProxyResponseTemplatesEdit page
- feat(console): impl edit mode for ApiProxyResponseTemplatesEditComponent
- fix(console): add save bar with submit button inside form (+gioFormFocusInvalid)
- feat(console): impl headers & body input for ApiProxyResponseTemplatesEditComponent
- fix(console): add `*` on required field
- feat(console): impl status code input for ApiProxyResponseTemplatesEditComponent
- feat(console): start impl ApiProxyResponseTemplatesEditComponent form
- feat(console): init empty ApiProxyResponseTemplatesEditComponent & refactor List component
- feat(console): impl response templates table
- feat(console): init empty ApiProxyResponseTemplatesComponent
### [fix: increased timeout to fix flaky ui-api-list test [2473]](https://github.com/gravitee-io/gravitee-api-management/pull/2473)
- fix: increased timeout to fix flaky ui-api-list test
### [fix: handle HTTP trailers in jupiter gateway fixes GRPC calls [2457]](https://github.com/gravitee-io/gravitee-api-management/pull/2457)
- fix: handle HTTP trailers in jupiter gateway fixes GRPC calls
### [[Snyk] Security upgrade redoc from 2.0.0-rc.53 to 2.0.0 [2458]](https://github.com/gravitee-io/gravitee-api-management/pull/2458)
- fix: gravitee-apim-portal-webui/package.json & gravitee-apim-portal-webui/package-lock.json to reduce vulnerabilities
### [fix(jupiter): better handle proxy error [2453]](https://github.com/gravitee-io/gravitee-api-management/pull/2453)
- fix(jupiter): better handle proxy error
### [fix: exclude unsupported fields from crd export [2452]](https://github.com/gravitee-io/gravitee-api-management/pull/2452)
- fix: exclude unsupported fields from crd export
### [[Console] Migrate API Proxy deployments screen [2450]](https://github.com/gravitee-io/gravitee-api-management/pull/2450)
- fix(console): add permission check for ApiProxyCorsComponent form
- feat(console): disable field when api origin is kubernetes
- feat(console): impl ApiProxyDeploymentsComponent form
- feat(console): init empty ApiProxyDeploymentsComponent
### [8403 - Add policy at message level [2438]](https://github.com/gravitee-io/gravitee-api-management/pull/2438)
- feat: apply policies on messages for async subscription api
- feat: apply policies on messages for async api
### [[Console] Migrate API Proxy Cors screen [2441]](https://github.com/gravitee-io/gravitee-api-management/pull/2441)
- feat(console): disable field when api origin is not kubernetes
- feat(console): impl full cors form
- feat(console): impl form with AllowOrigin & AllowMethods fields
- feat(console): init empty ApiProxyCorsComponent
### [fix: remove typo for information [2447]](https://github.com/gravitee-io/gravitee-api-management/pull/2447)
- fix: remove typo for information
### [ feat(perf): add keyless api body policies scenario  [2442]](https://github.com/gravitee-io/gravitee-api-management/pull/2442)
- feat(perf): add keyless api body policies scenario
- fix(perf): set good definition version for keyless scenario
- fix(perf): resolve flows setup for head policies scenario
### [feat: turn API wording to uppercase in API list add button [2443]](https://github.com/gravitee-io/gravitee-api-management/pull/2443)
- feat: turn API wording to uppercase in API list add button
### [feat(message): add identifier on message [2436]](https://github.com/gravitee-io/gravitee-api-management/pull/2436)
- feat(message): add identifier on message
### [[Management] API read-only if managed by CRD - Part 2 [2432]](https://github.com/gravitee-io/gravitee-api-management/pull/2432)
- feat(console): add snackbar to display success or error message
- fix(console): fix virtualHostMode Enabled 🤦‍♂️
- fix(console): rest all FromGroup on discard changes
- feat(console): disable field when api origin is not management
- feat(console): impl domain restriction validator & selector for host
- feat(console): impl add & remove virtual-host button
- feat(console): add focus on invalid field
### [feat: export api definition as a crd [2431]](https://github.com/gravitee-io/gravitee-api-management/pull/2431)
- feat: export api definition as a crd
### [fix: vertx timers memory leak [2424]](https://github.com/gravitee-io/gravitee-api-management/pull/2424)
- fix: make reponse wrappers properly close wrapped responses
- fix: properly cancel vertx timeout timer in Jupiter V3 compatibility mode
### [[Console] Start Migration of api proxy entrypoints [2430]](https://github.com/gravitee-io/gravitee-api-management/pull/2430)
- feat(console): impl virtual-host table - only display and edit existing hosts
- feat(console): impl switch btw context-path & virtual-host
- feat(console): impl update context-path from
- feat(console): init empty ApiProxyEntrypointsComponent
### [fix(): fix gateway api version [2422]](https://github.com/gravitee-io/gravitee-api-management/pull/2422)
- fix(): fix gateway api version
### [Fix connector config deserialization [2417]](https://github.com/gravitee-io/gravitee-api-management/pull/2417)
- fix(): fix after review
- feat(): add attributes on message
- fix(): add FactoryHelper to hold common behaviour across connector factory.

</details>

## Jira issues

[See all Jira issues for 3.20.x version](https://gravitee.atlassian.net/jira/software/c/projects/APIM/issues/?jql=project%20%3D%20%22APIM%22%20and%20fixVersion%20%3D%203.20.1%20and%20status%20%3D%20Done%20ORDER%20BY%20created%20DESC)
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://graviteedocs.blob.core.windows.net/release-apim-3-20-1/index.html)
<!-- UI placeholder end -->
