### PR TITLE
[APIM] Add changelog for new 3.19.8 release

### DIFF
--- a/pages/apim/3.x/changelog/changelog-3.19.adoc
+++ b/pages/apim/3.x/changelog/changelog-3.19.adoc
@@ -13,6 +13,31 @@ For upgrade instructions, please refer to https://docs.gravitee.io/apim/3.x/apim
 
 // <DO NOT REMOVE THIS COMMENT - ANCHOR FOR FUTURE RELEASES>
  
+== APIM - 3.19.8 (2023-02-24)
+
+=== Gateway
+
+* Fix technical API endpoints: `/_node/monitor` and `/_node/configuration` https://github.com/gravitee-io/issues/issues/8838[#8838] & https://github.com/gravitee-io/issues/issues/8875[#8875]
+* Wait for caches to be populated before moving to ready when starting the gateway https://github.com/gravitee-io/issues/issues/8866[#8866]
+* Revoke subscriptions when Client ID is changed https://github.com/gravitee-io/issues/issues/8883[#8883]
+
+=== API
+
+* Do not duplicate flows when some dynamic properties are scheduled https://github.com/gravitee-io/issues/issues/8844[#8844]
+* Properly manage user's firstname and lastname, API names and application names containing accents https://github.com/gravitee-io/issues/issues/8847[#8847]
+* Do not override `application_groups` data when upgrading from 3.15 to 3.19 with JDBC https://github.com/gravitee-io/issues/issues/8876[#8876]
+* Unable to access Gateway instances screen when DB contains a lot of events https://github.com/gravitee-io/issues/issues/8898[#8898]
+* Error when loading Identity Provider with id in uppercase https://github.com/gravitee-io/issues/issues/8900[#8900]
+* Update default password policy pattern https://github.com/gravitee-io/issues/issues/8905[#8905]
+
+=== Console
+
+* Special characters are truncated inside a query param https://github.com/gravitee-io/issues/issues/8903[#8903]
+
+=== Portal
+
+* Fix Redoc documentation integration https://github.com/gravitee-io/issues/issues/8703[#8703]
+ 
 == APIM - 3.19.7 (2023-02-03)
 
 === API


### PR DESCRIPTION

# New APIM version 3.19.8 has been released
📝 You can modify the changelog template online [here](https://github.com/gravitee-io/gravitee-docs/edit/release-apim-3.19.8/pages/apim/3.x/changelog/changelog-3.19.adoc)

Here is some information to help with the writing:

## Pull requests
<details>
  <summary>See all Pull Requests</summary>

### [Display full query param values when they contain `=` in them (backport #3150) [3157]](https://github.com/gravitee-io/gravitee-api-management/pull/3157)
- fix: display full query param values when they contain `=` in them
### [fix: update user password policy regex (backport #3149) [3154]](https://github.com/gravitee-io/gravitee-api-management/pull/3154)
- fix: update user password policy regex
### [fix: avoid adding Redoc script in dom dynamically [ 3.19.x ] [3141]](https://github.com/gravitee-io/gravitee-api-management/pull/3141)
- fix: avoid adding Redoc script in dom dynamically
### [filter gateway started expired events  (backport #3126) [3135]](https://github.com/gravitee-io/gravitee-api-management/pull/3135)
- fix: filter expired gateway started events
### [Correctly handle IDP with name containing upper case character (backport #3127) [3132]](https://github.com/gravitee-io/gravitee-api-management/pull/3132)
- fix: correctly handle IDP with name containing upper case character
### [Remove all entries of a subscription from cache (backport #3117) [3121]](https://github.com/gravitee-io/gravitee-api-management/pull/3121)
- fix: evict properly subscriptions from cache
### [Merge 3.18 into 3.19 [3122]](https://github.com/gravitee-io/gravitee-api-management/pull/3122)
- fix: validation messages are never displayed
- fix: bump swagger version
- fix: set sync probe to true when caches are fully loaded
### [Update validation spec in API proxy config schema form [3106]](https://github.com/gravitee-io/gravitee-api-management/pull/3106)
- fix: update validation spec in API proxy config schema form
### [fix(repository): use default application.findAll to have group filled [3103]](https://github.com/gravitee-io/gravitee-api-management/pull/3103)
- fix(repository): use default application.findAll to have group filled
### [Display redundant spaces in API, Application and Plan deletion popup (backport #3090) [3093]](https://github.com/gravitee-io/gravitee-api-management/pull/3093)
- fix: display redundant spaces in API, Application and Plan deletion popup
### [Display redundant spaces in API, Application and Plan deletion popup [3090]](https://github.com/gravitee-io/gravitee-api-management/pull/3090)
- fix: display redundant spaces in API, Application and Plan deletion popup
### [Merge 3.19.x [3044]](https://github.com/gravitee-io/gravitee-api-management/pull/3044)
- fix: sanitize name of new API
- fix: sanitize name and description of new Plan
- fix: sanitize name and description of new Application
- fix: sanitize firstname and lastname of NewExternalUserEntity
### [Sanitize some fields of new ExternalUser, Application, Plan [3035]](https://github.com/gravitee-io/gravitee-api-management/pull/3035)
- fix: sanitize name of new API
- fix: sanitize name and description of new Plan
- fix: sanitize name and description of new Application
- fix: sanitize firstname and lastname of NewExternalUserEntity
### [fix: use id for save flows [2962]](https://github.com/gravitee-io/gravitee-api-management/pull/2962)
- fix: stop the dynamic properties service when it's disabled
- fix: use dedicated thread pool executor for dynamic properties
- feat: ignore plans and flows when update dynamic properties
- fix: use id to save flows
### [fix: add search to log filters to improve performances [2993]](https://github.com/gravitee-io/gravitee-api-management/pull/2993)
- fix: add search to log filters to improve performances

</details>

## Jira issues

[See all Jira issues for 3.19.x version](https://gravitee.atlassian.net/jira/software/c/projects/APIM/issues/?jql=project%20%3D%20%22APIM%22%20and%20fixVersion%20%3D%203.19.8%20and%20status%20%3D%20Done%20ORDER%20BY%20created%20DESC)
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://graviteedocs.blob.core.windows.net/release-apim-3-19-8/index.html)
<!-- UI placeholder end -->
