### PR TITLE
Add doc about the configuration of transaction and request id headers

### DIFF
--- a/pages/apim/3.x/installation-guide/configuration/gateway/installation-guide-gateway-configuration.adoc
+++ b/pages/apim/3.x/installation-guide/configuration/gateway/installation-guide-gateway-configuration.adoc
@@ -349,6 +349,47 @@ organizations: mycompany
 environments: dev,integration
 ----
 
+=== Configure Transaction Id and Request Id Headers
+
+By default, the APIM Gateway will generate an id for each request and set it in the following headers:
+
+- `X-Gravitee-Transaction-Id` for the transaction id
+- `X-Gravitee-Request-Id` for the request id
+
+Both these headers can be customized. You can provide your own header names:
+
+[source,yaml]
+----
+handlers:
+  request:
+    transaction:
+      header: X-Custom-Transaction-Id
+    request:
+      header: X-Custom-Request-Id
+----
+
+Also, you can configure the APIM Gateway behavior when the backend itself sets the same headers.
+To do so you need to set the `overrideMode` attribute, the following values are available:
+
+  - `override`: The header set by the APIM Gateway will override the one provided by the backend
+  - `merge`: Both headers set by the APIM Gateway and the backend will be kept (as headers can be multivalued)
+  - `keep`: The header set by the backend will be kept and the one provided by the APIM Gateway discarded
+
+Both transaction and request headers can be configured independently:
+
+[source,yaml]
+----
+handlers:
+  request:
+    transaction:
+      header: X-Custom-Transaction-Id
+      overrideMode: merge
+    request:
+      header: X-Custom-Request-Id
+      overrideMode: keep
+----
+
+
 === Default configuration
 
 You can configure various default properties of APIM Gateway in your `gravitee.yml` file.


### PR DESCRIPTION
**Issue**

https://gravitee.atlassian.net/browse/APIM-75
gravitee-io/issues#7618

**Description**

Add doc about the configuration of transaction and request id headers. 
Override mode will be available in 3.18.20+, 3.19.9+, 3.20.3+


<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://graviteedocs.blob.core.windows.net/apim-75-add-doc-about-backendoverridemode/index.html)
<!-- UI placeholder end -->
