### PR TITLE
[APIM] Add changelog for new 3.18.20 release

### DIFF
--- a/pages/apim/3.x/changelog/changelog-3.18.adoc
+++ b/pages/apim/3.x/changelog/changelog-3.18.adoc
@@ -13,6 +13,40 @@ For upgrade instructions, please refer to https://docs.gravitee.io/apim/3.x/apim
 
 // <DO NOT REMOVE THIS COMMENT - ANCHOR FOR FUTURE RELEASES>
  
+== APIM - 3.18.20 (2023-03-10)
+
+=== Gateway
+
+* No circuit breaker applied on an unhealthy API when dynamic routing is activated https://github.com/gravitee-io/issues/issues/8919[#8919]
+* Gateway exceeded memory limit for $group with mongodb atlas https://github.com/gravitee-io/issues/issues/8914[#8914]
+* Server error on flow selection in best-match mode https://github.com/gravitee-io/issues/issues/8899[#8899]
+* Traffic shadowing policy is not compatible with the latest versions of APIM https://github.com/gravitee-io/issues/issues/8385[#8385]
+* Synchronization error on startup with multiple environments on SQL database https://github.com/gravitee-io/issues/issues/8929[#8929]
+
+=== API
+
+* Pagination issue with APIs on different environments https://github.com/gravitee-io/issues/issues/8923[#8923]
+* API can not be updated properly if a plan's name contains a `+` character https://github.com/gravitee-io/issues/issues/8909[#8909]
+* Password policy pattern not consistent between code and config file https://github.com/gravitee-io/issues/issues/8905[#8905]
+* Error when loading Identity Provider with id in uppercase https://github.com/gravitee-io/issues/issues/8900[#8900]
+* Can not export API after using "Import multiple files" feature https://github.com/gravitee-io/issues/issues/8828[#8828]
+* Some characters are not supported in a MongoDB URI https://github.com/gravitee-io/issues/issues/8643[#8643]
+* Multiple values of Transaction header when `handlers` is set https://github.com/gravitee-io/issues/issues/7618[#7618]
+
+=== Console
+
+* Special characters are truncated inside a query param https://github.com/gravitee-io/issues/issues/8903[#8903]
+* Unable to access Gateway instances screen when DB contains a lot of events https://github.com/gravitee-io/issues/issues/8898[#8898]
+* Cropped tooltip when charts contain a lot of series https://github.com/gravitee-io/issues/issues/5852[#5852]
+* Pagination of the API properties table is not working https://github.com/gravitee-io/issues/issues/7048[#7048]
+* Response Template for `SPIKE_ARREST_TOO_MANY_REQUESTS` missing https://github.com/gravitee-io/issues/issues/7082[#7082]
+
+=== Portal
+
+* Non-required fields displayed as required in OpenAPI documentation https://github.com/gravitee-io/issues/issues/7099[#7099]
+* Redoc documentation is not working and keeps loading https://github.com/gravitee-io/issues/issues/8703[#8703]
+
+ 
 == APIM - 3.18.19 (2023-02-17)
 
 === Gateway

--- a/pages/apim/3.x/changelog/changelog-3.20.adoc
+++ b/pages/apim/3.x/changelog/changelog-3.20.adoc
@@ -17,8 +17,8 @@ For upgrade instructions, please refer to https://docs.gravitee.io/apim/3.x/apim
 
 === Gateway
 
-* Gateway exceeded memory limit for $group with mongodb https://github.com/gravitee-io/issues/issues/8914[#8914]
-* Null value during bestmatch flow selection. https://github.com/gravitee-io/issues/issues/8899[#8899]
+* Gateway exceeded memory limit for $group with mongodb atlas https://github.com/gravitee-io/issues/issues/8914[#8914]
+* Server error on flow selection in best-match mode https://github.com/gravitee-io/issues/issues/8899[#8899]
 * Fix technical API endpoints: `/_node/monitor` and `/_node/configuration` https://github.com/gravitee-io/issues/issues/8838[#8838] & https://github.com/gravitee-io/issues/issues/8875[#8875]
 * Wait for caches to be populated before moving to ready when starting the gateway https://github.com/gravitee-io/issues/issues/8866[#8866]
 * Revoke subscriptions when Client ID is changed https://github.com/gravitee-io/issues/issues/8883[#8883]
@@ -27,14 +27,14 @@ For upgrade instructions, please refer to https://docs.gravitee.io/apim/3.x/apim
 
 * Do not duplicate flows when some dynamic properties are scheduled https://github.com/gravitee-io/issues/issues/8844[#8844]
 * Do not override `application_groups` data when upgrading from 3.15 to 3.19 with JDBC https://github.com/gravitee-io/issues/issues/8876[#8876]
-* Unable to access Gateway instances screen when DB contains a lot of events https://github.com/gravitee-io/issues/issues/8898[#8898]
 * Error when loading Identity Provider with id in uppercase https://github.com/gravitee-io/issues/issues/8900[#8900]
-* Update default password policy pattern https://github.com/gravitee-io/issues/issues/8905[#8905]
+* Password policy pattern not consistent between code and config file https://github.com/gravitee-io/issues/issues/8905[#8905]
 
 === Console
 
+* Unable to access Gateway instances screen when DB contains a lot of events https://github.com/gravitee-io/issues/issues/8898[#8898]
 * API version missing in UI https://github.com/gravitee-io/issues/issues/8904[#8904]
-* SPIKE_ARREST_TOO_MANY_REQUESTS missing in Response Template drop down. https://github.com/gravitee-io/issues/issues/7082[#7082]
+* Response Template for `SPIKE_ARREST_TOO_MANY_REQUESTS` missing https://github.com/gravitee-io/issues/issues/7082[#7082]
 * Special characters are truncated inside a query param https://github.com/gravitee-io/issues/issues/8903[#8903]
 * Properly display multiple spaces in API name https://github.com/gravitee-io/issues/issues/8867[#8867]
 * Allow to save disabled proxy settings when system proxy is ON https://github.com/gravitee-io/issues/issues/8698[#8698]


### PR DESCRIPTION

# New APIM version 3.18.20 has been released
📝 You can modify the changelog template online [here](https://github.com/gravitee-io/gravitee-docs/edit/release-apim-3.18.20/pages/apim/3.x/changelog/changelog-3.18.adoc)

Here is some information to help with the writing:

## Pull requests
<details>
  <summary>See all Pull Requests</summary>

### [fix: export api with multiple pages fetched from github [3259]](https://github.com/gravitee-io/gravitee-api-management/pull/3259)
- fix: skip page fetch on root pages
### [Handle special characters in user/password of MongoDB uri [3258]](https://github.com/gravitee-io/gravitee-api-management/pull/3258)
- fix: handle special characters in user/password of MongoDB uri
### [Add different mode for transaction header override [3169]](https://github.com/gravitee-io/gravitee-api-management/pull/3169)
- fix: introduce a TransactionResponseProcessor
### [fix: bump traffic shadowing version to 2.0.0 [3250]](https://github.com/gravitee-io/gravitee-api-management/pull/3250)
- fix: bump traffic shadowing version to 2.0.0
### [Use JSON schema with JS-YAML lib to convert YAML to JSON [3242]](https://github.com/gravitee-io/gravitee-api-management/pull/3242)
- fix: use JSON SCHEMA to convert YAML to JSON
### [fix(gateway): configure stream before handling connection [3236]](https://github.com/gravitee-io/gravitee-api-management/pull/3236)
- fix(gateway): configure stream before handling connection
### [Bump `@gravitee/ui-components` to `3.38.8` [3226]](https://github.com/gravitee-io/gravitee-api-management/pull/3226)
- fix: bump `@gravitee/ui-components` to `3.38.8`
### [Update managedEndpoint status with healthcheck service. [3224]](https://github.com/gravitee-io/gravitee-api-management/pull/3224)
- fix: update status of original endpoint
### [Filter by environment when searching APIs with SearchEngine [3204]](https://github.com/gravitee-io/gravitee-api-management/pull/3204)
- fix: filter by environment when searching APIs with SearchEngine
### [Fix best match flow selector [3190]](https://github.com/gravitee-io/gravitee-api-management/pull/3190)
- fix: fix best match flow selector
### [fix: optimize search latest mongodb query [3177]](https://github.com/gravitee-io/gravitee-api-management/pull/3177)
- fix: optimize search latest mongodb query
### [Add SPIKE_ARREST_TOO_MANY_REQUESTS template key [3160]](https://github.com/gravitee-io/gravitee-api-management/pull/3160)
- fix: add SPIKE_ARREST_TOO_MANY_REQUESTS template key
### [Display full query param values when they contain `=` in them [3150]](https://github.com/gravitee-io/gravitee-api-management/pull/3150)
- fix: display full query param values when they contain `=` in them
### [fix: update user password policy regex [3149]](https://github.com/gravitee-io/gravitee-api-management/pull/3149)
- fix: update user password policy regex
### [Remove redoc script loading [3137]](https://github.com/gravitee-io/gravitee-api-management/pull/3137)
- fix: avoid adding Redoc script in dom dynamically
### [filter gateway started expired events  [3126]](https://github.com/gravitee-io/gravitee-api-management/pull/3126)
- fix: filter expired gateway started events
### [Correctly handle IDP with name containing upper case character [3127]](https://github.com/gravitee-io/gravitee-api-management/pull/3127)
- fix: correctly handle IDP with name containing upper case character
### [Bump Swagger version [3114]](https://github.com/gravitee-io/gravitee-api-management/pull/3114)
- fix: validation messages are never displayed
- fix: bump swagger version

</details>

## Jira issues

[See all Jira issues for 3.18.x version](https://gravitee.atlassian.net/jira/software/c/projects/APIM/issues/?jql=project%20%3D%20%22APIM%22%20and%20fixVersion%20%3D%203.18.20%20and%20status%20%3D%20Done%20ORDER%20BY%20created%20DESC)
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://graviteedocs.blob.core.windows.net/release-apim-3-18-20/index.html)
<!-- UI placeholder end -->
