### PR TITLE
docs: add organization and environment ids in gko context definitions

### DIFF
--- a/pages/apim/3.x/kubernetes/apim-kubernetes-operator-definitions.adoc
+++ b/pages/apim/3.x/kubernetes/apim-kubernetes-operator-definitions.adoc
@@ -35,6 +35,8 @@ metadata:
   name: dev-mgmt-ctx
 spec:
   baseUrl: http://localhost:8083
+  environmentId: DEFAULT
+  organizationId: DEFAULT
   auth:
     credentials:
       username: admin
@@ -51,6 +53,8 @@ metadata:
   name: dev-mgmt-ctx
 spec:
   baseUrl: http://localhost:8083
+  environmentId: DEFAULT
+  organizationId: DEFAULT
   auth:
     bearerToken: xxxx-yyyy-zzzz
 ....


### PR DESCRIPTION
**Description**

Current GKO ManagementContext examples are wrong. Environment and organization ids are required when users try to push it on the cluster.

**Additional context**

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->

<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://graviteedocs.blob.core.windows.net/docs-mgmt-context/index.html)
<!-- UI placeholder end -->
