### PR TITLE
docs: include developper guide from apim repository

### DIFF
--- a/pages/apim/3.x/dev-guide/dev-guide-boostrap.adoc
+++ b/pages/apim/3.x/dev-guide/dev-guide-boostrap.adoc
@@ -5,4 +5,4 @@
 :page-folder: apim/dev-guide
 :page-layout: apim3x
 
-include::https://raw.githubusercontent.com/gravitee-io/gravitee-api-management/master/CONTRIBUTING.adoc[tag=dev-guide]
+include::https://raw.githubusercontent.com/gravitee-io/gravitee-api-management/master/CONTRIBUTING.adoc[leveloffset=-1,tag=dev-guide]


### PR DESCRIPTION
**Issue**

https://gravitee.atlassian.net/browse/APIM-1096

**Description**

Move developper guide in APIM.
An other issue is coming to update the documentation content itself.

## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://graviteedocs.blob.core.windows.net/apim-1096-include-apim-dev-guide/index.html)
<!-- UI placeholder end -->
