### PR TITLE
[APIM] Add changelog for new 3.19.9 release

### DIFF
--- a/pages/apim/3.x/changelog/changelog-3.18.adoc
+++ b/pages/apim/3.x/changelog/changelog-3.18.adoc
@@ -22,6 +22,7 @@ For upgrade instructions, please refer to https://docs.gravitee.io/apim/3.x/apim
 * Server error on flow selection in best-match mode https://github.com/gravitee-io/issues/issues/8899[#8899]
 * Traffic shadowing policy is not compatible with the latest versions of APIM https://github.com/gravitee-io/issues/issues/8385[#8385]
 * Synchronization error on startup with multiple environments on SQL database https://github.com/gravitee-io/issues/issues/8929[#8929]
+* Multiple values of Transaction header when `handlers` is set https://github.com/gravitee-io/issues/issues/7618[#7618]
 
 === API
 
@@ -31,7 +32,6 @@ For upgrade instructions, please refer to https://docs.gravitee.io/apim/3.x/apim
 * Error when loading Identity Provider with id in uppercase https://github.com/gravitee-io/issues/issues/8900[#8900]
 * Can not export API after using "Import multiple files" feature https://github.com/gravitee-io/issues/issues/8828[#8828]
 * Some characters are not supported in a MongoDB URI https://github.com/gravitee-io/issues/issues/8643[#8643]
-* Multiple values of Transaction header when `handlers` is set https://github.com/gravitee-io/issues/issues/7618[#7618]
 
 === Console
 

--- a/pages/apim/3.x/changelog/changelog-3.19.adoc
+++ b/pages/apim/3.x/changelog/changelog-3.19.adoc
@@ -13,6 +13,43 @@ For upgrade instructions, please refer to https://docs.gravitee.io/apim/3.x/apim
 
 // <DO NOT REMOVE THIS COMMENT - ANCHOR FOR FUTURE RELEASES>
  
+== APIM - 3.19.9 (2023-03-17)
+
+=== Gateway
+
+* Server error on flow selection in best-match mode https://github.com/gravitee-io/issues/issues/8899[#8899]
+* No circuit breaker applied on an unhealthy API when dynamic routing is activated https://github.com/gravitee-io/issues/issues/8919[#8919]
+* Gateway exceeded memory limit for $group with mongodb atlas https://github.com/gravitee-io/issues/issues/8914[#8914]
+* Health-check fails if endpoint host contains an underscore https://github.com/gravitee-io/issues/issues/8946[#8946]
+* Gateway timeout is not logged when API is called by another API https://github.com/gravitee-io/issues/issues/8941[#8941]
+* Synchronization error on startup with multiple environments on SQL database https://github.com/gravitee-io/issues/issues/8929[#8929]
+* Error when starting the Gateway with Kubernetes values https://github.com/gravitee-io/issues/issues/8927[#8927]
+* Multiple values of Transaction header when `handlers` is set https://github.com/gravitee-io/issues/issues/7618[#7618]
+
+=== API
+
+* Can not export API after using "Import multiple files" feature https://github.com/gravitee-io/issues/issues/8828[#8828]
+* API can not be updated properly if a plan's name contains a `+` character https://github.com/gravitee-io/issues/issues/8909[#8909]
+* Pagination issue with APIs on different environments https://github.com/gravitee-io/issues/issues/8923[#8923]
+* Search by payload does not work properly with special characters https://github.com/gravitee-io/issues/issues/8470[#8470]
+* Some characters are not supported in a MongoDB URI https://github.com/gravitee-io/issues/issues/8643[#8643]
+
+=== Console
+
+* Transfer ownership of API does not automatically display current members https://github.com/gravitee-io/issues/issues/8516[#8516]
+* API version missing in API list screen https://github.com/gravitee-io/issues/issues/8904[#8904]
+* Cropped tooltip when charts contain a lot of series https://github.com/gravitee-io/issues/issues/5852[#5852]
+* Pagination of the API properties table is not working https://github.com/gravitee-io/issues/issues/7048[#7048]
+* Response Template for `SPIKE_ARREST_TOO_MANY_REQUESTS` missing https://github.com/gravitee-io/issues/issues/7082[#7082]
+
+=== Portal
+
+* Non-required fields displayed as required in OpenAPI documentation https://github.com/gravitee-io/issues/issues/7099[#7099]
+
+=== Policies
+
+* Traffic shadowing policy is not compatible with the latest versions of APIM https://github.com/gravitee-io/issues/issues/8385[#8385]
+
 == APIM - 3.19.8 (2023-02-24)
 
 === Gateway


### PR DESCRIPTION

# New APIM version 3.19.9 has been released
📝 You can modify the changelog template online [here](https://github.com/gravitee-io/gravitee-docs/edit/release-apim-3.19.9/pages/apim/3.x/changelog/changelog-3.19.adoc)

Here is some information to help with the writing:

## Pull requests
<details>
  <summary>See all Pull Requests</summary>

### [fix: bump notifier-api & notifier email - 3.19.x [3315]](https://github.com/gravitee-io/gravitee-api-management/pull/3315)
- fix: bump notifier-api & notifier email
### [fix: bump elastic reporter to 3.12.5 - 3.19.x [3309]](https://github.com/gravitee-io/gravitee-api-management/pull/3309)
- fix: bump elastic reporter to 3.12.5
### [Allow underscore in hostname for HealthCheck service - 3.19.x [3303]](https://github.com/gravitee-io/gravitee-api-management/pull/3303)
- fix: allow underscore in hostname
### [Display list of API members in the transfer ownership screen - 3.19.x [3308]](https://github.com/gravitee-io/gravitee-api-management/pull/3308)
- fix: display list of API members in the transfer ownership screen
### [fix: log all timeouts when chaining calls - 3.19.x [3294]](https://github.com/gravitee-io/gravitee-api-management/pull/3294)
- fix: log all timeouts when chaining calls
### [fix: log all timeouts when chaining calls [3280]](https://github.com/gravitee-io/gravitee-api-management/pull/3280)
- fix: log all timeouts when chaining calls
### [fix: escape uri components in log queries - 3.19.x [3279]](https://github.com/gravitee-io/gravitee-api-management/pull/3279)
- fix: escape uri components in log queries
### [fix: escape uri components in log queries [3272]](https://github.com/gravitee-io/gravitee-api-management/pull/3272)
- fix: escape uri components in log queries
### [Bump gravitee-node to `1.25.3` [3270]](https://github.com/gravitee-io/gravitee-api-management/pull/3270)
- fix: bump gravitee-node to `1.25.3`
### [fix: export api with multiple pages fetched from github - 3.19.x [3265]](https://github.com/gravitee-io/gravitee-api-management/pull/3265)
- fix: skip page fetch on root pages
### [fix: export api with multiple pages fetched from github [3259]](https://github.com/gravitee-io/gravitee-api-management/pull/3259)
- fix: skip page fetch on root pages
### [Add different mode for transaction header override - 3.19.x [3241]](https://github.com/gravitee-io/gravitee-api-management/pull/3241)
- fix: introduce a TransactionPostProcessor
- fix: introduce a TransactionResponseProcessor
### [Handle special characters in user/password of MongoDB uri - 3.19.x [3262]](https://github.com/gravitee-io/gravitee-api-management/pull/3262)
- fix: handle special characters in user/password of MongoDB uri
### [Handle special characters in user/password of MongoDB uri [3258]](https://github.com/gravitee-io/gravitee-api-management/pull/3258)
- fix: handle special characters in user/password of MongoDB uri
### [Add different mode for transaction header override [3169]](https://github.com/gravitee-io/gravitee-api-management/pull/3169)
- fix: introduce a TransactionResponseProcessor
### [fix: bump traffic shadowing version to 2.0.0 - 3.19.x [3257]](https://github.com/gravitee-io/gravitee-api-management/pull/3257)
- fix: bump traffic shadowing version to 2.0.0
### [fix: bump traffic shadowing version to 2.0.0 [3250]](https://github.com/gravitee-io/gravitee-api-management/pull/3250)
- fix: bump traffic shadowing version to 2.0.0
### [Use JSON schema with JS-YAML lib to convert YAML to JSON (backport #3242) [3246]](https://github.com/gravitee-io/gravitee-api-management/pull/3246)
- fix: use JSON SCHEMA to convert YAML to JSON
### [Use JSON schema with JS-YAML lib to convert YAML to JSON [3242]](https://github.com/gravitee-io/gravitee-api-management/pull/3242)
- fix: use JSON SCHEMA to convert YAML to JSON
### [fix(gateway): configure stream before handling connection (backport #3236) [3240]](https://github.com/gravitee-io/gravitee-api-management/pull/3240)
- fix(gateway): configure stream before handling connection
### [fix(gateway): configure stream before handling connection [3236]](https://github.com/gravitee-io/gravitee-api-management/pull/3236)
- fix(gateway): configure stream before handling connection
### [Update managedEndpoint status with healthcheck service. (backport #3224) [3229]](https://github.com/gravitee-io/gravitee-api-management/pull/3229)
- fix: update status of original endpoint
### [Bump `@gravitee/ui-components` to `3.38.8` [3226]](https://github.com/gravitee-io/gravitee-api-management/pull/3226)
- fix: bump `@gravitee/ui-components` to `3.38.8`
### [Update managedEndpoint status with healthcheck service. [3224]](https://github.com/gravitee-io/gravitee-api-management/pull/3224)
- fix: update status of original endpoint
### [Filter by environment when searching APIs with SearchEngine - `3.19.x` [3221]](https://github.com/gravitee-io/gravitee-api-management/pull/3221)
- fix: filter by environment when searching APIs with SearchEngine
### [Filter by environment when searching APIs with SearchEngine [3204]](https://github.com/gravitee-io/gravitee-api-management/pull/3204)
- fix: filter by environment when searching APIs with SearchEngine
### [fix: optimize search latest mongodb query (backport #3177) [3207]](https://github.com/gravitee-io/gravitee-api-management/pull/3207)
- fix: optimize search latest mongodb query
### [Fix best match flow selector (backport #3190) [3193]](https://github.com/gravitee-io/gravitee-api-management/pull/3193)
- fix: fix best match flow selector
### [Fix best match flow selector [3190]](https://github.com/gravitee-io/gravitee-api-management/pull/3190)
- fix: fix best match flow selector
### [fix: optimize search latest mongodb query [3177]](https://github.com/gravitee-io/gravitee-api-management/pull/3177)
- fix: optimize search latest mongodb query
### [Display API version in APIs list [3170]](https://github.com/gravitee-io/gravitee-api-management/pull/3170)
- fix: fix type in APIs list screen
- fix: display API version in APIs list
### [Add SPIKE_ARREST_TOO_MANY_REQUESTS template key (backport #3160) [3162]](https://github.com/gravitee-io/gravitee-api-management/pull/3162)
- fix: add SPIKE_ARREST_TOO_MANY_REQUESTS template key
### [Add SPIKE_ARREST_TOO_MANY_REQUESTS template key [3160]](https://github.com/gravitee-io/gravitee-api-management/pull/3160)
- fix: add SPIKE_ARREST_TOO_MANY_REQUESTS template key
### [Display full query param values when they contain `=` in them [3150]](https://github.com/gravitee-io/gravitee-api-management/pull/3150)
- fix: display full query param values when they contain `=` in them
### [fix: update user password policy regex [3149]](https://github.com/gravitee-io/gravitee-api-management/pull/3149)
- fix: update user password policy regex
### [Remove redoc script loading [3137]](https://github.com/gravitee-io/gravitee-api-management/pull/3137)
- fix: avoid adding Redoc script in dom dynamically
### [filter gateway started expired events  [3126]](https://github.com/gravitee-io/gravitee-api-management/pull/3126)
- fix: filter expired gateway started events
### [Correctly handle IDP with name containing upper case character [3127]](https://github.com/gravitee-io/gravitee-api-management/pull/3127)
- fix: correctly handle IDP with name containing upper case character

</details>

## Jira issues

[See all Jira issues for 3.19.x version](https://gravitee.atlassian.net/jira/software/c/projects/APIM/issues/?jql=project%20%3D%20%22APIM%22%20and%20fixVersion%20%3D%203.19.9%20and%20status%20%3D%20Done%20ORDER%20BY%20created%20DESC)
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://graviteedocs.blob.core.windows.net/release-apim-3-19-9/index.html)
<!-- UI placeholder end -->
