### PR TITLE
Add new BC for Redis repository plugin and update installation guide …

### DIFF
--- a/pages/apim/3.x/installation-guide/configuration/repositories/installation-guide-repositories-redis.adoc
+++ b/pages/apim/3.x/installation-guide/configuration/repositories/installation-guide-repositories-redis.adoc
@@ -13,6 +13,10 @@ This repository plugin is for connecting to Redis databases for Rate Limit featu
 
 == Install the Rate Limit repository plugin
 
+[WARNING]
+====
+From version 3.21.0, you do not need to download the plugin since it is embedded in the distribution. You only need to configure the repository as described in step 3.
+====
 Repeat these steps on each component (APIM Gateway and APIM API) where the SQL database is used.
 
 . Download the plugin corresponding to your APIM version (take the latest maintenance release).
@@ -35,6 +39,7 @@ ratelimit:
     port:                   # redis port (default 6379)
     password:               # redis password (default null)
     timeout:                # redis timeout (default -1)
+    ssl:                    # redis ssl mode (default false)
 
     # Following properties are REQUIRED ONLY when running Redis in sentinel mode
     sentinel:

--- a/pages/apim/3.x/installation-guide/upgrades/3.21.0/README.adoc
+++ b/pages/apim/3.x/installation-guide/upgrades/3.21.0/README.adoc
@@ -16,3 +16,7 @@ securityContext:
 In previous versions, sending a POST request to /user/login without an Authorization returned HTTP Response 200.
 
 Starting with 3.21.0, if a POST request to /user/login does not have an Authorization header, it will receive a HTTP response 401 - Unauthorized.
+
+=== Redis repository plugin
+Starting with 3.21.0, the Redis repository plugin is embedded in the distribution meaning that you do not need to download and install it on your own.
+The helm chart has been updated to manage this change by checking the version and only allowing to download the plugin if needed for version prior to 3.21.0.


### PR DESCRIPTION
…as it is now embedded in distribution in APIM 3.21.0

**Description**

Add BC for Redis repository plugin and update installation guide as it is now embedded in distribution (and add the ssl option in the configuration section as it was missing)


<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://graviteedocs.blob.core.windows.net/feat-vertx-redis-client/index.html)
<!-- UI placeholder end -->
