### PR TITLE
[APIM] Add changelog for new 3.20.3 release

### DIFF
--- a/pages/apim/3.x/changelog/changelog-3.20.adoc
+++ b/pages/apim/3.x/changelog/changelog-3.20.adoc
@@ -13,6 +13,52 @@ For upgrade instructions, please refer to https://docs.gravitee.io/apim/3.x/apim
 
 // <DO NOT REMOVE THIS COMMENT - ANCHOR FOR FUTURE RELEASES>
  
+== APIM - 3.20.3 (2023-03-27)
+
+=== Gateway
+
+* Multiple values of Transaction header when `handlers` is set https://github.com/gravitee-io/issues/issues/7618[#7618]
+* No circuit breaker applied on an unhealthy API when dynamic routing is activated https://github.com/gravitee-io/issues/issues/8919[#8919]
+* Error when starting the Gateway with Kubernetes values https://github.com/gravitee-io/issues/issues/8927[#8927]
+* Synchronization error on startup with multiple environments on SQL database https://github.com/gravitee-io/issues/issues/8929[#8929]
+* Gateway timeout is not logged when API is called by another API https://github.com/gravitee-io/issues/issues/8941[#8941]
+* Consumer response logs are missing when using the Jupiter engine https://github.com/gravitee-io/issues/issues/8942[#8942]
+* Health-check fails if endpoint host contains an underscore https://github.com/gravitee-io/issues/issues/8946[#8946]
+* Chunk corruption with TLS and HTTP 1.1  https://github.com/gravitee-io/issues/issues/8956[#8956]
+* Random 503 error when using {#properties['backend']} on endpoint target https://github.com/gravitee-io/issues/issues/8959[#8959]
+* Wrong value in `proxy-request.headers.host` with Jupiter execution mode https://github.com/gravitee-io/issues/issues/8961[#8961]
+
+=== API
+
+* Response from the request "Attach a media to a portal page" does not give all data like in the documentation https://github.com/gravitee-io/issues/issues/6787[#6787]
+* Search by payload does not work properly with special characters https://github.com/gravitee-io/issues/issues/8470[#8470]
+* Some characters are not supported in a MongoDB URI https://github.com/gravitee-io/issues/issues/8643[#8643]
+* Can not export API after using "Import multiple files" feature https://github.com/gravitee-io/issues/issues/8828[#8828]
+* Pagination issue with APIs on different environments https://github.com/gravitee-io/issues/issues/8923[#8923]
+* Sending notifications is not possible when there are two subscriptions to a single application https://github.com/gravitee-io/issues/issues/8939[#8939]
+
+=== Console
+
+* Cropped tooltip when charts contain a lot of series https://github.com/gravitee-io/issues/issues/5852[#5852]
+* Pagination of the API properties table is not working https://github.com/gravitee-io/issues/issues/7048[#7048]
+* Not possible to remove General conditions from a plan https://github.com/gravitee-io/issues/issues/8465[#8465]
+* Transfer ownership of API does not automatically display current members https://github.com/gravitee-io/issues/issues/8516[#8516]
+* Dashboard shows all APIs stopped when all APIs are started https://github.com/gravitee-io/issues/issues/8760[#8760]
+* API can not be updated properly if a plan's name contains a `+` character https://github.com/gravitee-io/issues/issues/8909[#8909]
+* API Endpoint configuration is lost when saving healthcheck configuration https://github.com/gravitee-io/issues/issues/8947[#8947]
+
+=== Portal
+
+* Non-required fields displayed as required in OpenAPI documentation https://github.com/gravitee-io/issues/issues/7099[#7099]
+
+=== Other
+
+* Policy SSL Enforcement can be configured with invalid DN https://github.com/gravitee-io/issues/issues/6457[#6457]
+* Traffic shadowing policy is not compatible with the latest versions of APIM https://github.com/gravitee-io/issues/issues/8385[#8385]
+* Email notifier not handling properly newline in alert body https://github.com/gravitee-io/issues/issues/8752[#8752]
+* XMLtoJSON policy does not execute based on Content-Type header value https://github.com/gravitee-io/issues/issues/8953[#8953]
+
+ 
 == APIM - 3.20.2 (2023-03-03)
 
 === Gateway


### PR DESCRIPTION

# New APIM version 3.20.3 has been released
📝 You can modify the changelog template online [here](https://github.com/gravitee-io/gravitee-docs/edit/release-apim-3.20.3/pages/apim/3.x/changelog/changelog-3.20.adoc)

Here is some information to help with the writing:

## Pull requests
<details>
  <summary>See all Pull Requests</summary>

### [Handle application with no group when sending notification - 3.20.x [3412]](https://github.com/gravitee-io/gravitee-api-management/pull/3412)
- fix: handle application with no group when sending notification
### [Do not throw when sending notif to app owner with multiple subscriptions - 3.20.x [3404]](https://github.com/gravitee-io/gravitee-api-management/pull/3404)
- fix: bump `policy-regex-threat-protection` to `1.3.3`
- fix: do not throw when sending notif to app owner with multiple subscription to the same API
### [Do not throw when sending notif to app owner with multiple subscriptions - 3.19.x [3405]](https://github.com/gravitee-io/gravitee-api-management/pull/3405)
- fix: bump `policy-regex-threat-protection` to `1.3.3`
- fix: do not throw when sending notif to app owner with multiple subscription to the same API
### [fix: match documentation and implementation for attach media api - 3.20.x [3388]](https://github.com/gravitee-io/gravitee-api-management/pull/3388)
- fix: match documentation and implementation for attach media api
### [fix: match documentation and implementation for attach media api - 3.19.x [3389]](https://github.com/gravitee-io/gravitee-api-management/pull/3389)
- fix: match documentation and implementation for attach media api
### [Bump dependencies - 3.20.x [3394]](https://github.com/gravitee-io/gravitee-api-management/pull/3394)
- fix: bump `gravitee-policy-ssl-enforcement` to `1.2.2`
- fix: bump `gravitee-connector-http` to `2.1.3`
### [Bump dependencies - 3.19.x [3395]](https://github.com/gravitee-io/gravitee-api-management/pull/3395)
- fix: bump `gravitee-policy-ssl-enforcement` to `1.2.2`
- fix: bump `gravitee-connector-http` to `2.1.3`
### [fix: put backend host in proxy request headers log [3385]](https://github.com/gravitee-io/gravitee-api-management/pull/3385)
- fix: put backend host in proxy request headers log
### [Use ApiKeyAuthHandler when ApiKey is provided but invalid [3299]](https://github.com/gravitee-io/gravitee-api-management/pull/3299)
- fix: use ApiKeyAuthHandler when ApiKey is provided but invalid
### [Properly select series labels in pie chart - 3.20.x [3381]](https://github.com/gravitee-io/gravitee-api-management/pull/3381)
- fix: properly select series' labels in pie chart
### [Properly select series labels in pie chart - 3.19.x [3382]](https://github.com/gravitee-io/gravitee-api-management/pull/3382)
- fix: properly select series' labels in pie chart
### [Update `connector-http` to `2.1.2` - 3.20.x [3365]](https://github.com/gravitee-io/gravitee-api-management/pull/3365)
- fix: update `connector-http` to `2.1.2`
### [Update `connector-http` to `2.1.2` - 3.19.x [3366]](https://github.com/gravitee-io/gravitee-api-management/pull/3366)
- fix: update `connector-http` to `2.1.2`
### [Add an empty option when selecting the general condition of a plan - 3.19.x [3363]](https://github.com/gravitee-io/gravitee-api-management/pull/3363)
- fix: add an empty option when selecting general condition of a plan
### [Add an empty option when selecting the general condition of a plan - 3.20.x [3362]](https://github.com/gravitee-io/gravitee-api-management/pull/3362)
- fix: add an empty option when selecting general condition of a plan
### [fix: add client response in logs with jupiter - 3.19.x [3351]](https://github.com/gravitee-io/gravitee-api-management/pull/3351)
- fix: add client response in logs with jupiter
- fix: add client response in logs with jupiter
### [Update `policy-xml-json` to `1.8.2` - 3.19.x [3357]](https://github.com/gravitee-io/gravitee-api-management/pull/3357)
- fix: update `policy-xml-json` to `1.8.2`
### [Update `policy-xml-json` to `1.8.2` - 3.20.x [3356]](https://github.com/gravitee-io/gravitee-api-management/pull/3356)
- fix: update `policy-xml-json` to `1.8.2`
### [fix: add client response in logs with jupiter [3333]](https://github.com/gravitee-io/gravitee-api-management/pull/3333)
- fix: add client response in logs with jupiter
### [3.20.x - Console - API Endpoint configuration is lost when saving healthcheck configuration [3319]](https://github.com/gravitee-io/gravitee-api-management/pull/3319)
- fix(console): health check inherit is enable by default
- fix(console): do not lose proxyConfig when changing the healthcheck config
### [fix: bump notifier-api & notifier email - 3.20.x [3314]](https://github.com/gravitee-io/gravitee-api-management/pull/3314)
- fix: bump notifier-api & notifier email
### [fix: bump notifier-api & notifier email - 3.19.x [3315]](https://github.com/gravitee-io/gravitee-api-management/pull/3315)
- fix: bump notifier-api & notifier email
### [fix: bump elastic reporter to 3.12.5 - 3.19.x [3309]](https://github.com/gravitee-io/gravitee-api-management/pull/3309)
- fix: bump elastic reporter to 3.12.5
### [Allow underscore in hostname for HealthCheck service - 3.19.x [3303]](https://github.com/gravitee-io/gravitee-api-management/pull/3303)
- fix: allow underscore in hostname
### [Display list of API members in the transfer ownership screen - 3.20.x [3307]](https://github.com/gravitee-io/gravitee-api-management/pull/3307)
- fix: display list of API members in the transfer ownership screen
### [Display list of API members in the transfer ownership screen - 3.19.x [3308]](https://github.com/gravitee-io/gravitee-api-management/pull/3308)
- fix: display list of API members in the transfer ownership screen
### [fix: bump elastic reporter to 4.0.1 [3306]](https://github.com/gravitee-io/gravitee-api-management/pull/3306)
- fix: bump elastic reporter to 4.0.1
### [Allow underscore in hostname for HealthCheck service [3300]](https://github.com/gravitee-io/gravitee-api-management/pull/3300)
- fix: allow underscore in hostname
### [fix: log all timeouts when chaining calls - 3.20.x [3293]](https://github.com/gravitee-io/gravitee-api-management/pull/3293)
- fix: log all timeouts when chaining calls
### [fix: log all timeouts when chaining calls - 3.19.x [3294]](https://github.com/gravitee-io/gravitee-api-management/pull/3294)
- fix: log all timeouts when chaining calls
### [fix: log all timeouts when chaining calls [3280]](https://github.com/gravitee-io/gravitee-api-management/pull/3280)
- fix: log all timeouts when chaining calls
### [fix: escape uri components in log queries - 3.20.x [3278]](https://github.com/gravitee-io/gravitee-api-management/pull/3278)
- fix: escape uri components in log queries
### [fix: escape uri components in log queries - 3.19.x [3279]](https://github.com/gravitee-io/gravitee-api-management/pull/3279)
- fix: escape uri components in log queries
### [fix: escape uri components in log queries [3272]](https://github.com/gravitee-io/gravitee-api-management/pull/3272)
- fix: escape uri components in log queries
### [fix: configure kubernetes synchronizer to watch All or specific names… [3275]](https://github.com/gravitee-io/gravitee-api-management/pull/3275)
- fix: configure kubernetes synchronizer to watch All or specific namespaces
### [Bump gravitee-node to `2.0.5` [3271]](https://github.com/gravitee-io/gravitee-api-management/pull/3271)
- fix: bump gravitee-node to `2.0.5`
### [Bump gravitee-node to `1.25.3` [3270]](https://github.com/gravitee-io/gravitee-api-management/pull/3270)
- fix: bump gravitee-node to `1.25.3`
### [Add different mode for transaction header override - 3.20.x [3268]](https://github.com/gravitee-io/gravitee-api-management/pull/3268)
- fix: introduce a TransactionPostProcessor
- fix: introduce a TransactionResponseProcessor
### [fix: export api with multiple pages fetched from github - 3.20.x [3264]](https://github.com/gravitee-io/gravitee-api-management/pull/3264)
- fix: skip page fetch on root pages
### [fix: export api with multiple pages fetched from github - 3.19.x [3265]](https://github.com/gravitee-io/gravitee-api-management/pull/3265)
- fix: skip page fetch on root pages
### [fix: export api with multiple pages fetched from github [3259]](https://github.com/gravitee-io/gravitee-api-management/pull/3259)
- fix: skip page fetch on root pages
### [Add different mode for transaction header override - 3.19.x [3241]](https://github.com/gravitee-io/gravitee-api-management/pull/3241)
- fix: introduce a TransactionPostProcessor
- fix: introduce a TransactionResponseProcessor
### [Handle special characters in user/password of MongoDB uri - 3.20.x [3261]](https://github.com/gravitee-io/gravitee-api-management/pull/3261)
- fix: handle special characters in user/password of MongoDB uri
### [Handle special characters in user/password of MongoDB uri - 3.19.x [3262]](https://github.com/gravitee-io/gravitee-api-management/pull/3262)
- fix: handle special characters in user/password of MongoDB uri
### [Handle special characters in user/password of MongoDB uri [3258]](https://github.com/gravitee-io/gravitee-api-management/pull/3258)
- fix: handle special characters in user/password of MongoDB uri
### [Add different mode for transaction header override [3169]](https://github.com/gravitee-io/gravitee-api-management/pull/3169)
- fix: introduce a TransactionResponseProcessor
### [fix: bump traffic shadowing version to 2.0.0 - 3.19.x [3257]](https://github.com/gravitee-io/gravitee-api-management/pull/3257)
- fix: bump traffic shadowing version to 2.0.0
### [fix: bump traffic shadowing version to 2.0.0 - 3.20.x [3256]](https://github.com/gravitee-io/gravitee-api-management/pull/3256)
- fix: bump traffic shadowing version to 2.0.0
### [fix: bump traffic shadowing version to 2.0.0 [3250]](https://github.com/gravitee-io/gravitee-api-management/pull/3250)
- fix: bump traffic shadowing version to 2.0.0
### [Filter by environment when searching APIs with SearchEngine - `3.19.x` (backport #3221) [3222]](https://github.com/gravitee-io/gravitee-api-management/pull/3222)
- fix: filter by environment when searching APIs with SearchEngine
### [Use JSON schema with JS-YAML lib to convert YAML to JSON (backport #3242) [3245]](https://github.com/gravitee-io/gravitee-api-management/pull/3245)
- fix: use JSON SCHEMA to convert YAML to JSON
### [Use JSON schema with JS-YAML lib to convert YAML to JSON (backport #3242) [3246]](https://github.com/gravitee-io/gravitee-api-management/pull/3246)
- fix: use JSON SCHEMA to convert YAML to JSON
### [Use JSON schema with JS-YAML lib to convert YAML to JSON [3242]](https://github.com/gravitee-io/gravitee-api-management/pull/3242)
- fix: use JSON SCHEMA to convert YAML to JSON
### [fix(gateway): configure stream before handling connection (backport #3236) [3240]](https://github.com/gravitee-io/gravitee-api-management/pull/3240)
- fix(gateway): configure stream before handling connection
### [fix(gateway): configure stream before handling connection (backport #3236) [3239]](https://github.com/gravitee-io/gravitee-api-management/pull/3239)
- fix(gateway): configure stream before handling connection
### [fix(gateway): configure stream before handling connection [3236]](https://github.com/gravitee-io/gravitee-api-management/pull/3236)
- fix(gateway): configure stream before handling connection
### [Update managedEndpoint status with healthcheck service. (backport #3224) [3228]](https://github.com/gravitee-io/gravitee-api-management/pull/3228)
- fix: update status of original endpoint
### [Update managedEndpoint status with healthcheck service. (backport #3224) [3229]](https://github.com/gravitee-io/gravitee-api-management/pull/3229)
- fix: update status of original endpoint
### [Bump `@gravitee/ui-components` to `3.38.8` [3226]](https://github.com/gravitee-io/gravitee-api-management/pull/3226)
- fix: bump `@gravitee/ui-components` to `3.38.8`
### [Update managedEndpoint status with healthcheck service. [3224]](https://github.com/gravitee-io/gravitee-api-management/pull/3224)
- fix: update status of original endpoint
### [Filter by environment when searching APIs with SearchEngine - `3.19.x` [3221]](https://github.com/gravitee-io/gravitee-api-management/pull/3221)
- fix: filter by environment when searching APIs with SearchEngine
### [Filter by environment when searching APIs with SearchEngine [3204]](https://github.com/gravitee-io/gravitee-api-management/pull/3204)
- fix: filter by environment when searching APIs with SearchEngine
### [fix: optimize search latest mongodb query (backport #3177) [3207]](https://github.com/gravitee-io/gravitee-api-management/pull/3207)
- fix: optimize search latest mongodb query
### [Fix best match flow selector (backport #3190) [3193]](https://github.com/gravitee-io/gravitee-api-management/pull/3193)
- fix: fix best match flow selector
### [Fix best match flow selector [3190]](https://github.com/gravitee-io/gravitee-api-management/pull/3190)
- fix: fix best match flow selector
### [fix: optimize search latest mongodb query [3177]](https://github.com/gravitee-io/gravitee-api-management/pull/3177)
- fix: optimize search latest mongodb query
### [Display API version in APIs list [3170]](https://github.com/gravitee-io/gravitee-api-management/pull/3170)
- fix: fix type in APIs list screen
- fix: display API version in APIs list
### [Add SPIKE_ARREST_TOO_MANY_REQUESTS template key (backport #3160) [3162]](https://github.com/gravitee-io/gravitee-api-management/pull/3162)
- fix: add SPIKE_ARREST_TOO_MANY_REQUESTS template key
### [Add SPIKE_ARREST_TOO_MANY_REQUESTS template key [3160]](https://github.com/gravitee-io/gravitee-api-management/pull/3160)
- fix: add SPIKE_ARREST_TOO_MANY_REQUESTS template key
### [Display full query param values when they contain `=` in them [3150]](https://github.com/gravitee-io/gravitee-api-management/pull/3150)
- fix: display full query param values when they contain `=` in them
### [fix: update user password policy regex [3149]](https://github.com/gravitee-io/gravitee-api-management/pull/3149)
- fix: update user password policy regex
### [Remove redoc script loading [3137]](https://github.com/gravitee-io/gravitee-api-management/pull/3137)
- fix: avoid adding Redoc script in dom dynamically
### [filter gateway started expired events  [3126]](https://github.com/gravitee-io/gravitee-api-management/pull/3126)
- fix: filter expired gateway started events
### [Correctly handle IDP with name containing upper case character [3127]](https://github.com/gravitee-io/gravitee-api-management/pull/3127)
- fix: correctly handle IDP with name containing upper case character

</details>

## Jira issues

[See all Jira issues for 3.20.x version](https://gravitee.atlassian.net/jira/software/c/projects/APIM/issues/?jql=project%20%3D%20%22APIM%22%20and%20fixVersion%20%3D%203.20.3%20and%20status%20%3D%20Done%20ORDER%20BY%20created%20DESC)
