### PR TITLE
[APIM] Add changelog for new 3.20.4 release

### DIFF
--- a/pages/apim/3.x/changelog/changelog-3.20.adoc
+++ b/pages/apim/3.x/changelog/changelog-3.20.adoc
@@ -13,6 +13,14 @@ For upgrade instructions, please refer to https://docs.gravitee.io/apim/3.x/apim
 
 // <DO NOT REMOVE THIS COMMENT - ANCHOR FOR FUTURE RELEASES>
  
+== APIM - 3.20.4 (2023-03-30)
+
+=== API
+
+* All API displayed as out of sync even if no change was done https://github.com/gravitee-io/issues/issues/8954[#8954]
+* Missing PK on `subscriptions_metadata` table https://github.com/gravitee-io/issues/issues/8967[#8967]
+* Data lost when upgrading to 3.18+ with JDBC database https://github.com/gravitee-io/issues/issues/8980[#8980]
+
 == APIM - 3.20.3 (2023-03-27)
 
 === Gateway


### PR DESCRIPTION

# New APIM version 3.20.4 has been released
📝 You can modify the changelog template online [here](https://github.com/gravitee-io/gravitee-docs/edit/release-apim-3.20.4/pages/apim/3.x/changelog/changelog-3.20.adoc)

Here is some information to help with the writing:

## Pull requests
<details>
  <summary>See all Pull Requests</summary>

### [Remove definition context from api history - 3.20.x [3473]](https://github.com/gravitee-io/gravitee-api-management/pull/3473)
- fix: delete definition context from api history
### [fix: remove use of `ApiRepository.findAll` - 3.20.x [3465]](https://github.com/gravitee-io/gravitee-api-management/pull/3465)
- fix: remove use of `ApiRepository.findAll`
### [Exclude Flow Ids from API Sync check - 3.20.x [3455]](https://github.com/gravitee-io/gravitee-api-management/pull/3455)
- fix: allow use of personal token on the Portal API
### [Add missing PK on `subscriptions_metadata` table  [3416]](https://github.com/gravitee-io/gravitee-api-management/pull/3416)
- fix: add missing PK on `subscriptions_metadata` table

</details>

## Jira issues

[See all Jira issues for 3.20.x version](https://gravitee.atlassian.net/jira/software/c/projects/APIM/issues/?jql=project%20%3D%20%22APIM%22%20and%20fixVersion%20%3D%203.20.4%20and%20status%20%3D%20Done%20ORDER%20BY%20created%20DESC)
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://graviteedocs.blob.core.windows.net/release-apim-3-20-4/index.html)
<!-- UI placeholder end -->
