### PR TITLE
Update mongodb script links to use our internal DNS

### DIFF
--- a/pages/am/3.x/installation-guide/installation-guide-migration.adoc
+++ b/pages/am/3.x/installation-guide/installation-guide-migration.adoc
@@ -4,8 +4,6 @@
 :page-folder: am/installation-guide
 :page-layout: am
 
-NOTE: Files specified in this guide can be found at https://github.com/gravitee-io/graviteeio-access-management/tree/master/docs/upgrades
-
 WARNING: If you plan to skip versions when you upgrade, ensure that you read the version-specific upgrade notes for each intermediate version. You may be required to perform manual actions as part of the upgrade.
 
 WARNING: Make sure to run scripts on the correct database since `gravitee-am` is not always the default database! Check your db name by running `show dbs`.
@@ -117,11 +115,11 @@ NOTE: For more information about the breaking changes of this version, see link:
 
 Before you run any scripts, create a dump of your existing database.
 
-https://raw.githubusercontent.com/gravitee-io/gravitee-access-management/master/docs/upgrades/3.x/3.17.0/mongodb/1-migrate-application-identities.js[upgrades/3.x/3.17.0/mongodb/1-migrate-application-identities.js]::
+https://gh.gravitee.io/gravitee-io/gravitee-access-management/master/docs/upgrades/3.x/3.17.0/mongodb/1-migrate-application-identities.js[upgrades/3.x/3.17.0/mongodb/1-migrate-application-identities.js]::
 
 This script will migrate data structure of the application settings to manage the selection rules and ordering of the identity providers.
 
-https://raw.githubusercontent.com/gravitee-io/gravitee-access-management/master/docs/upgrades/3.x/3.17.0/mongodb/1-add-saml2-permissions.js[upgrades/3.x/3.17.0/mongodb/1-add-saml2-permissions.js]::
+https://gh.gravitee.io/gravitee-io/gravitee-access-management/master/docs/upgrades/3.x/3.17.0/mongodb/1-add-saml2-permissions.js[upgrades/3.x/3.17.0/mongodb/1-add-saml2-permissions.js]::
 
 This script will create the DOMAIN_SAML and APPLICATION_SAML permission.
 
@@ -139,7 +137,7 @@ NOTE: For more information about the breaking changes of this version, see link:
 
 Before you run any scripts, create a dump of your existing database.
 
-https://raw.githubusercontent.com/gravitee-io/gravitee-access-management/master/docs/upgrades/3.x/3.15.0/mongodb/1-add-authdevice-notifier-permissions.js[upgrades/3.x/3.15.0/mongodb/1-add-authdevice-notifier-permissions.js]::
+https://gh.gravitee.io/gravitee-io/gravitee-access-management/master/docs/upgrades/3.x/3.15.0/mongodb/1-add-authdevice-notifier-permissions.js[upgrades/3.x/3.15.0/mongodb/1-add-authdevice-notifier-permissions.js]::
 
 This script will create the DOMAIN_AUTHDEVICE_NOTIFIER permission.
 
@@ -169,11 +167,11 @@ GitHub issue: link:https://github.com/gravitee-io/issues/issues/7080[7080]
 
 Before you run any scripts, create a dump of your existing database.
 
-https://raw.githubusercontent.com/gravitee-io/gravitee-access-management/master/docs/upgrades/3.x/3.13.0/mongodb/1-add-device-identifier-permissions.js[upgrades/3.x/3.13.0/mongodb/1-add-device-identifier-permissions.js]::
+https://gh.gravitee.io/gravitee-io/gravitee-access-management/master/docs/upgrades/3.x/3.13.0/mongodb/1-add-device-identifier-permissions.js[upgrades/3.x/3.13.0/mongodb/1-add-device-identifier-permissions.js]::
 
 This script will create the DOMAIN_DEVICE_IDENTIFIER permission.
 
-https://raw.githubusercontent.com/gravitee-io/gravitee-access-management/master/docs/upgrades/3.x/3.13.0/mongodb/1-add-device-permissions.js[upgrades/3.x/3.13.0/mongodb/1-add-device-permissions.js]::
+https://gh.gravitee.io/gravitee-io/gravitee-access-management/master/docs/upgrades/3.x/3.13.0/mongodb/1-add-device-permissions.js[upgrades/3.x/3.13.0/mongodb/1-add-device-permissions.js]::
 
 This script will create the DOMAIN_USER_DEVICE permission.
 
@@ -300,7 +298,7 @@ NOTE: For more information about the breaking changes of this version please vis
 
 Before you run any scripts, create a dump of your existing database.
 
-https://raw.githubusercontent.com/gravitee-io/gravitee-access-management/master/docs/upgrades/3.x/3.8.0/mongodb/1-add-domain-hrid.js[upgrades/3.x/3.8.0/mongodb/1-add-domain-hrid.js]::
+https://gh.gravitee.io/gravitee-io/gravitee-access-management/master/docs/upgrades/3.x/3.8.0/mongodb/1-add-domain-hrid.js[upgrades/3.x/3.8.0/mongodb/1-add-domain-hrid.js]::
 This script updates the database to reflect the following changes :
 
 * Add hrid field to the security domains
@@ -313,7 +311,7 @@ This script updates the database to reflect the following changes :
 
 Before you run any scripts, create a dump of your existing database.
 
-https://raw.githubusercontent.com/gravitee-io/gravitee-access-management/master/docs/upgrades/3.x/3.7.0/mongodb/1-add-alert-permissions.js[upgrades/3.x/3.7.0/mongodb/1-add-alert-permissions.js]::
+https://gh.gravitee.io/gravitee-io/gravitee-access-management/master/docs/upgrades/3.x/3.7.0/mongodb/1-add-alert-permissions.js[upgrades/3.x/3.7.0/mongodb/1-add-alert-permissions.js]::
 This script updates the database to reflect the following changes :
 
 * Enable alerting support
@@ -328,7 +326,7 @@ NOTE: For more information about the breaking changes of this version please vis
 
 Before you run any scripts, create a dump of your existing database.
 
-https://raw.githubusercontent.com/gravitee-io/gravitee-access-management/master/docs/upgrades/3.x/3.6.0/mongodb/1-add-environment-permissions.js[upgrades/3.x/3.6.0/mongodb/1-add-environment-permissions.js]::
+https://gh.gravitee.io/gravitee-io/gravitee-access-management/master/docs/upgrades/3.x/3.6.0/mongodb/1-add-environment-permissions.js[upgrades/3.x/3.6.0/mongodb/1-add-environment-permissions.js]::
 This script updates the database to reflect the following changes :
 
 * Addition of new permissions related to the multi environments feature
@@ -354,7 +352,7 @@ NOTE: For more information about the breaking changes of this version please vis
 
 Before you run any scripts, create a dump of your existing database.
 
-https://raw.githubusercontent.com/gravitee-io/gravitee-access-management/master/docs/upgrades/3.x/3.4.0/mongodb/1-form-templates-migration.js[upgrades/3.x/3.4.0/mongodb/1-form-templates-migration]::
+https://gh.gravitee.io/gravitee-io/gravitee-access-management/master/docs/upgrades/3.x/3.4.0/mongodb/1-form-templates-migration.js[upgrades/3.x/3.4.0/mongodb/1-form-templates-migration]::
 This script updates the database to reflect the following changes :
 
 * Update form actions and links to make it work with the new cookie session
@@ -386,7 +384,7 @@ WARNING: We highly recommend that you run the MongoDB database script before sta
 
 Before you run any scripts, create a dump of your existing database.
 
-https://raw.githubusercontent.com/gravitee-io/gravitee-access-management/master/docs/upgrades/3.x/3.0.0/mongodb/1-migration-v3.js[upgrades/3.x/3.0.0/mongodb/1-migration-v3]::
+https://gh.gravitee.io/gravitee-io/gravitee-access-management/master/docs/upgrades/3.x/3.0.0/mongodb/1-migration-v3.js[upgrades/3.x/3.0.0/mongodb/1-migration-v3]::
 This script updates the database to reflect the following changes :
 
 * Adds new fields that refer the default environment and the default organization.

--- a/pages/apim/1.x/installation-guide/upgrades/1.0.0/README.adoc
+++ b/pages/apim/1.x/installation-guide/upgrades/1.0.0/README.adoc
@@ -11,40 +11,40 @@ Before running any script, please create a dump of your existing database:
 
 > mongodump --host "localhost:27017" --archive=/path/to/your/archive/gravitee.dump.archive --db gravitee
 
-link:https://raw.githubusercontent.com/gravitee-io/gravitee-api-management/master/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/resources/scripts/1.0.0/1-copy-members-to-memberships.js[/apim/1.x/mongodb/1-copy-members-to-memberships.js]::
+link:https://gh.gravitee.io/gravitee-io/gravitee-api-management/master/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/resources/scripts/1.0.0/1-copy-members-to-memberships.js[/apim/1.x/mongodb/1-copy-members-to-memberships.js]::
 This script creates the new `memberships` collection in MongoDB and add all api/application members.
 It does not remove old values from the `apis` and `applications` collections.
 
 > mongo gravitee < 1-copy-members-to-memberships.js
 
 
-link:https://raw.githubusercontent.com/gravitee-io/gravitee-api-management/master/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/resources/scripts/1.0.0/2-remove-members.js[/apim/1.x/mongodb/1.0.0/2-remove-members.js]::
+link:https://gh.gravitee.io/gravitee-io/gravitee-api-management/master/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/resources/scripts/1.0.0/2-remove-members.js[/apim/1.x/mongodb/1.0.0/2-remove-members.js]::
 This script removes old datas. **It must be run after** `1-copy-members-to-memberships.js`
 **This operation is irreversible**.
 
 > mongo gravitee < 2-remove-members.js
 
-link:https://raw.githubusercontent.com/gravitee-io/gravitee-api-management/master/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/resources/scripts/1.0.0/3-endpoint-configuration.js[/apim/1.x/mongodb/1.0.0/3-endpoint-configuration.js]::
+link:https://gh.gravitee.io/gravitee-io/gravitee-api-management/master/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/resources/scripts/1.0.0/3-endpoint-configuration.js[/apim/1.x/mongodb/1.0.0/3-endpoint-configuration.js]::
 **This operation is irreversible**.
 
 > mongo gravitee < 3-endpoint-configuration.js
 
-link:https://raw.githubusercontent.com/gravitee-io/gravitee-api-management/master/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/resources/scripts/1.0.0/4-remove-api-key-policy.js[/apim/1.x/mongodb/1.0.0/4-remove-api-key-policy.js]::
+link:https://gh.gravitee.io/gravitee-io/gravitee-api-management/master/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/resources/scripts/1.0.0/4-remove-api-key-policy.js[/apim/1.x/mongodb/1.0.0/4-remove-api-key-policy.js]::
 **This operation is irreversible**.
 
 > mongo gravitee < 4-remove-api-key-policy.js
 
-link:https://raw.githubusercontent.com/gravitee-io/gravitee-api-management/master/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/resources/scripts/1.0.0/5-update-published-api.js[/apim/1.x/mongodb/1.0.0/5-update-published-api.js]::
+link:https://gh.gravitee.io/gravitee-io/gravitee-api-management/master/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/resources/scripts/1.0.0/5-update-published-api.js[/apim/1.x/mongodb/1.0.0/5-update-published-api.js]::
 **This operation is irreversible**.
 
 > mongo gravitee < 5-update-published-api.js
 
-link:https://raw.githubusercontent.com/gravitee-io/gravitee-api-management/master/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/resources/scripts/1.0.0/6-default-plan-with-existing-apikeys.js[/apim/1.x/mongodb/1.0.0/6-default-plan-with-existing-apikeys.js]::
+link:https://gh.gravitee.io/gravitee-io/gravitee-api-management/master/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/resources/scripts/1.0.0/6-default-plan-with-existing-apikeys.js[/apim/1.x/mongodb/1.0.0/6-default-plan-with-existing-apikeys.js]::
 **This operation is irreversible**.
 
 > mongo gravitee < 6-default-plan-with-existing-apikeys.js
 
-link:https://raw.githubusercontent.com/gravitee-io/gravitee-api-management/master/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/resources/scripts/1.0.0/7-copy-views-to-api.js[/apim/1.x/mongodb/1.0.0/7-copy-views-to-api.js]::
+link:https://gh.gravitee.io/gravitee-io/gravitee-api-management/master/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/resources/scripts/1.0.0/7-copy-views-to-api.js[/apim/1.x/mongodb/1.0.0/7-copy-views-to-api.js]::
 **This operation is irreversible**.
 
 > mongo gravitee < 7-copy-views-to-api.js

--- a/pages/apim/1.x/installation-guide/upgrades/1.1.0/README.adoc
+++ b/pages/apim/1.x/installation-guide/upgrades/1.1.0/README.adoc
@@ -5,6 +5,6 @@
 
 Before running any script, please create a dump of your existing database.
 
-link:https://raw.githubusercontent.com/gravitee-io/gravitee-api-management/master/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/resources/scripts/1.1.0/1-update-plan.js[/apim/1.x/mongodb/1.1.0/1-update-plan.js]::
+link:https://gh.gravitee.io/gravitee-io/gravitee-api-management/master/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/resources/scripts/1.1.0/1-update-plan.js[/apim/1.x/mongodb/1.1.0/1-update-plan.js]::
 This script move existing plans to the `PUBLISHED` state for backward compatibility
 

--- a/pages/apim/1.x/installation-guide/upgrades/1.13.0/README.adoc
+++ b/pages/apim/1.x/installation-guide/upgrades/1.13.0/README.adoc
@@ -5,6 +5,6 @@
 
 Before running any script, please create a dump of your existing database.
 
-link:https://raw.githubusercontent.com/gravitee-io/gravitee-api-management/master/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/resources/scripts/1.13.0/1-move-api.js[/apim/1.x/mongodb/1.13.0/1-move-api.js]::
+link:https://gh.gravitee.io/gravitee-io/gravitee-api-management/master/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/resources/scripts/1.13.0/1-move-api.js[/apim/1.x/mongodb/1.13.0/1-move-api.js]::
 This script move API reference into the subscription object.
 

--- a/pages/apim/1.x/installation-guide/upgrades/1.14.0/README.adoc
+++ b/pages/apim/1.x/installation-guide/upgrades/1.14.0/README.adoc
@@ -5,10 +5,10 @@
 
 Before running any script, please create a dump of your existing database.
 
-link:https://raw.githubusercontent.com/gravitee-io/gravitee-api-management/master/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/resources/scripts/1.14.0/1-users-migration.js[/apim/1.x/mongodb/1.14.0/1-users-migration.js]::
+link:https://gh.gravitee.io/gravitee-io/gravitee-api-management/master/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/resources/scripts/1.14.0/1-users-migration.js[/apim/1.x/mongodb/1.14.0/1-users-migration.js]::
 This script remove plain username reference and prefer UUID.
 
-link:https://raw.githubusercontent.com/gravitee-io/gravitee-api-management/master/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/resources/scripts/1.14.0/mongodb/2-init-email-notifications.js[/apim/1.x/mongodb/1.14.0/2-init-email-notifications.js]::
+link:https://gh.gravitee.io/gravitee-io/gravitee-api-management/master/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/resources/scripts/1.14.0/mongodb/2-init-email-notifications.js[/apim/1.x/mongodb/1.14.0/2-init-email-notifications.js]::
 This script create a default email notifier for each Application and API Primary Owner.
 
 *This script is not mandatory !*

--- a/pages/apim/1.x/installation-guide/upgrades/1.20.0/README.adoc
+++ b/pages/apim/1.x/installation-guide/upgrades/1.20.0/README.adoc
@@ -8,5 +8,5 @@ To avoid incompatibilities on this version, the `Trust All` server certificates 
 
 === Mongodb
 
-link:https://raw.githubusercontent.com/gravitee-io/gravitee-api-management/master/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/resources/scripts/1.20.0/Migration.120.SSL.js[/apim/1.x/mongodb/1.20.0/Migration.120.SSL.js]::
+link:https://gh.gravitee.io/gravitee-io/gravitee-api-management/master/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/resources/scripts/1.20.0/Migration.120.SSL.js[/apim/1.x/mongodb/1.20.0/Migration.120.SSL.js]::
 This script update ssl endpoints to store the default configuration if not present.

--- a/pages/apim/1.x/installation-guide/upgrades/1.20.13/README.adoc
+++ b/pages/apim/1.x/installation-guide/upgrades/1.20.13/README.adoc
@@ -7,7 +7,7 @@ They must be unique in the all API and cannot contain `:`.
 
 === Mongodb
 
-link:https://raw.githubusercontent.com/gravitee-io/gravitee-api-management/master/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/resources/scripts/1.20.13/Find.Endpoints.duplicated.js[/apim/1.x/mongodb/1.20.13/Find.Endpoints.duplicated.js]::
+link:https://gh.gravitee.io/gravitee-io/gravitee-api-management/master/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/resources/scripts/1.20.13/Find.Endpoints.duplicated.js[/apim/1.x/mongodb/1.20.13/Find.Endpoints.duplicated.js]::
 This script find APIs where the uniqueness of endpoints name is not respected as the presence of the character `:` in the name.
 
 Example:

--- a/pages/apim/1.x/installation-guide/upgrades/1.23.0/README.adoc
+++ b/pages/apim/1.x/installation-guide/upgrades/1.23.0/README.adoc
@@ -15,5 +15,5 @@ If you want to allow all existing groups by default, run the following scripts
 == Repository
 === Mongodb
 
-link:https://raw.githubusercontent.com/gravitee-io/gravitee-api-management/master/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/resources/scripts/1.23.0/1-set-groups-invitation-mode.js[/apim/1.x/mongodb/1.23.0/1-set-groups-invitation-mode.js]::
+link:https://gh.gravitee.io/gravitee-io/gravitee-api-management/master/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/resources/scripts/1.23.0/1-set-groups-invitation-mode.js[/apim/1.x/mongodb/1.23.0/1-set-groups-invitation-mode.js]::
 (optional) This script updates invitation setting on every groups to make them working like before.

--- a/pages/apim/1.x/installation-guide/upgrades/1.25.0/README.adoc
+++ b/pages/apim/1.x/installation-guide/upgrades/1.25.0/README.adoc
@@ -11,8 +11,8 @@ To follow that new feature, the Rest Management API has been updated to reflect 
 == Repository
 === Mongodb
 
-link:https://raw.githubusercontent.com/gravitee-io/gravitee-api-management/master/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/resources/scripts/1.25.0/1-applications-migration.js[/apim/1.x/mongodb/1.25.0/1-applications-migration.js]::
+link:https://gh.gravitee.io/gravitee-io/gravitee-api-management/master/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/resources/scripts/1.25.0/1-applications-migration.js[/apim/1.x/mongodb/1.25.0/1-applications-migration.js]::
 This script update applications according to the new way Gravitee.io is managing them.
 
-link:https://raw.githubusercontent.com/gravitee-io/gravitee-api-management/master/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/resources/scripts/1.25.0/2-users-archived-upgrade.js[/apim/1.x/mongodb/1.25.0/mongodb/2-users-archived-upgrade.js]::
+link:https://gh.gravitee.io/gravitee-io/gravitee-api-management/master/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/resources/scripts/1.25.0/2-users-archived-upgrade.js[/apim/1.x/mongodb/1.25.0/mongodb/2-users-archived-upgrade.js]::
 This script update the sourceId of all archived users.

--- a/pages/apim/1.x/installation-guide/upgrades/1.25.23/README.adoc
+++ b/pages/apim/1.x/installation-guide/upgrades/1.25.23/README.adoc
@@ -3,5 +3,5 @@
 == Repository
 === Mongodb
 
-link:https://raw.githubusercontent.com/gravitee-io/gravitee-api-management/master/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/resources/scripts/1.25.23/1-memberships-archived-apps-migration.js[/apim/1.x/mongodb/1.25.23/1-memberships-archived-apps-migration.js]::
+link:https://gh.gravitee.io/gravitee-io/gravitee-api-management/master/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/resources/scripts/1.25.23/1-memberships-archived-apps-migration.js[/apim/1.x/mongodb/1.25.23/1-memberships-archived-apps-migration.js]::
 This script remove memberships of archived applications.

--- a/pages/apim/1.x/installation-guide/upgrades/1.26.0/README.adoc
+++ b/pages/apim/1.x/installation-guide/upgrades/1.26.0/README.adoc
@@ -9,5 +9,5 @@ To follow that new feature, the Rest Management API has been updated to reflect 
 == Repository
 === Mongodb
 
-link:https://raw.githubusercontent.com/gravitee-io/gravitee-api-management/master/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/resources/scripts/1.26.0/1-apis-migration.js[/apim/1.x/mongodb/1.26.0/1-apis-migration.js]::
+link:https://gh.gravitee.io/gravitee-io/gravitee-api-management/master/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/resources/scripts/1.26.0/1-apis-migration.js[/apim/1.x/mongodb/1.26.0/1-apis-migration.js]::
 This script update apis according to the new way Gravitee.io is managing them.

--- a/pages/apim/1.x/installation-guide/upgrades/1.4.0/README.adoc
+++ b/pages/apim/1.x/installation-guide/upgrades/1.4.0/README.adoc
@@ -11,10 +11,10 @@ This new configuration has exactly the same content as the previous one, minus t
 
 Before running any script, please create a dump of your existing database.
 
-link:https://raw.githubusercontent.com/gravitee-io/gravitee-api-management/master/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/resources/scripts/1.4.0/1-update-application.js[/apim/1.x/mongodb/1-update-application.js]::
+link:https://gh.gravitee.io/gravitee-io/gravitee-api-management/master/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/resources/scripts/1.4.0/1-update-application.js[/apim/1.x/mongodb/1-update-application.js]::
 This script creates the new `status` attribute on all applications with the default value `ACTIVE`.
 
-link:https://raw.githubusercontent.com/gravitee-io/gravitee-api-management/master/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/resources/scripts/1.4.0/2-create-archived-app.js[/apim/1.x/mongodb/2-create-archived-app.js]::
+link:https://gh.gravitee.io/gravitee-io/gravitee-api-management/master/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/resources/scripts/1.4.0/2-create-archived-app.js[/apim/1.x/mongodb/2-create-archived-app.js]::
 This script creates deleted apps with `status=ARCHIVED` for each subscriptions where there is no application associated.
 
 WARNING: edit the script before running it. You have to choose the user owner of the ARCHIVED applications.

--- a/pages/apim/1.x/installation-guide/upgrades/1.5.0/README.adoc
+++ b/pages/apim/1.x/installation-guide/upgrades/1.5.0/README.adoc
@@ -5,9 +5,9 @@
 
 Before running any script, please create a dump of your existing database.
 
-link:https://raw.githubusercontent.com/gravitee-io/gravitee-api-management/master/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/resources/scripts/1.5.0/1-remove-event-picture.js[/apim/1.x/mongodb/1.5.0/1-remove-event-picture.js]::
+link:https://gh.gravitee.io/gravitee-io/gravitee-api-management/master/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/resources/scripts/1.5.0/1-remove-event-picture.js[/apim/1.x/mongodb/1.5.0/1-remove-event-picture.js]::
 This script delete the picture from all API relative events because picture is useless and is disk consuming.
 
 
-link:https://raw.githubusercontent.com/gravitee-io/gravitee-api-management/master/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/resources/scripts/1.5.0/2-update-pages.js[/apim/1.x/mongodb/1.5.0/2-update-pages.js]::
+link:https://gh.gravitee.io/gravitee-io/gravitee-api-management/master/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/resources/scripts/1.5.0/2-update-pages.js[/apim/1.x/mongodb/1.5.0/2-update-pages.js]::
 This script set the homepage flag of all existing pages to false.

--- a/pages/apim/1.x/installation-guide/upgrades/1.8.0/README.adoc
+++ b/pages/apim/1.x/installation-guide/upgrades/1.8.0/README.adoc
@@ -5,7 +5,7 @@
 
 Before running any script, please create a dump of your existing database.
 
-link:https://raw.githubusercontent.com/gravitee-io/gravitee-api-management/master/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/resources/scripts/1.8.0/1-convert-roles.js[/apim/1.x/mongodb/1.8.0/1-convert-roles.js]::
+link:https://gh.gravitee.io/gravitee-io/gravitee-api-management/master/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/resources/scripts/1.8.0/1-convert-roles.js[/apim/1.x/mongodb/1.8.0/1-convert-roles.js]::
 This script convert old permission system to the new customized roles system.
 
 === AWS DynamoDB

--- a/pages/apim/1.x/installation-guide/upgrades/1.9.0/README.adoc
+++ b/pages/apim/1.x/installation-guide/upgrades/1.9.0/README.adoc
@@ -42,9 +42,9 @@ is still valid and is equivalent to:
 
 Before running any script, please create a dump of your existing database.
 
-link:https://raw.githubusercontent.com/gravitee-io/gravitee-api-management/master/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/resources/scripts/1.9.0/1-convert-groups.js[/apim/1.x/mongodb/1.9.0/1-convert-groups.js]::
+link:https://gh.gravitee.io/gravitee-io/gravitee-api-management/master/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/resources/scripts/1.9.0/1-convert-groups.js[/apim/1.x/mongodb/1.9.0/1-convert-groups.js]::
 This script convert old group system to the new one.
 
-link:https://raw.githubusercontent.com/gravitee-io/gravitee-api-management/master/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/resources/scripts/1.9.0/2-remove-old-attributes.js[/apim/1.x/mongodb/1.9.0/2-remove-old-attributes.js]::
+link:https://gh.gravitee.io/gravitee-io/gravitee-api-management/master/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/resources/scripts/1.9.0/2-remove-old-attributes.js[/apim/1.x/mongodb/1.9.0/2-remove-old-attributes.js]::
 This script remove all non requisite attributes.
 

--- a/pages/apim/3.x/installation-guide/configuration/repositories/installation-guide-repositories-mongodb.adoc
+++ b/pages/apim/3.x/installation-guide/configuration/repositories/installation-guide-repositories-mongodb.adoc
@@ -143,7 +143,7 @@ By default, these values are empty.
 
 NOTE: Before running any scripts, you must create a dump of your existing database. You need to repeat these steps on both APIM Gateway and APIM API.
 
-. To prefix your collections, you need to rename them. You can use following https://raw.githubusercontent.com/gravitee-io/gravitee-api-management/master/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/resources/scripts/3.7.0/1-rename-collections-with-prefix.js[this script^], which renames all the collections by adding a prefix and rateLimitPrefix of your choice.
+. To prefix your collections, you need to rename them. You can use following https://gh.gravitee.io/gravitee-io/gravitee-api-management/master/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/resources/scripts/3.7.0/1-rename-collections-with-prefix.js[this script^], which renames all the collections by adding a prefix and rateLimitPrefix of your choice.
 . Update values `management.mongodb.prefix` and `ratelimit.mongodb.prefix` in the `gravitee.yml` file.
 
 == Index

--- a/pages/apim/3.x/installation-guide/upgrades/3.0.0/README.adoc
+++ b/pages/apim/3.x/installation-guide/upgrades/3.0.0/README.adoc
@@ -88,29 +88,29 @@ Here's a correlation table of permissions before and after migration :
 
 Before running any script, please create a dump of your existing database.
 
-link:https://raw.githubusercontent.com/gravitee-io/gravitee-api-management/master/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/resources/scripts/3.0.0/1-collections-linked-to-environment-or-organization.js[/apim/3.x/mongodb/3.0.0/1-collections-linked-to-environment-or-organization.js]::
+link:https://gh.gravitee.io/gravitee-io/gravitee-api-management/master/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/resources/scripts/3.0.0/1-collections-linked-to-environment-or-organization.js[/apim/3.x/mongodb/3.0.0/1-collections-linked-to-environment-or-organization.js]::
 This script adds new fields that refer the default environment or the default organization.
 
-link:https://raw.githubusercontent.com/gravitee-io/gravitee-api-management/master/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/resources/scripts/3.0.0/2-roles-groups-and-memberships-migration.js[/apim/3.x/mongodb/3.0.0/2-roles-groups-and-memberships-migration.js]::
+link:https://gh.gravitee.io/gravitee-io/gravitee-api-management/master/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/resources/scripts/3.0.0/2-roles-groups-and-memberships-migration.js[/apim/3.x/mongodb/3.0.0/2-roles-groups-and-memberships-migration.js]::
 This script migrates permission values in roles since MANAGEMENT roles and PORTAL roles have been merged and dispatched into new ENVIRONMENT and ORGANIZATION roles.
 It also updates memberships and groups by adding or removing columns.
 All previous indexes for *roles* and *memberships* will be deleted and replaced by new indexes.
 
-link:https://raw.githubusercontent.com/gravitee-io/gravitee-api-management/master/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/resources/scripts/3.0.0/3-replace-apiArray-by-unique-api.js[/apim/3.x/mongodb/3.0.0/3-replace-apiArray-by-unique-api.js]::
+link:https://gh.gravitee.io/gravitee-io/gravitee-api-management/master/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/resources/scripts/3.0.0/3-replace-apiArray-by-unique-api.js[/apim/3.x/mongodb/3.0.0/3-replace-apiArray-by-unique-api.js]::
 This script adds a new field that refers the api and remove the api array.
 All previous indexes for *plans* will be deleted and replaced by new indexes.
 
-link:https://raw.githubusercontent.com/gravitee-io/gravitee-api-management/master/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/resources/scripts/3.0.0/4-remove-devMode.js[/apim/3.x/mongodb/3.0.0/4-remove-devMode.js]::
+link:https://gh.gravitee.io/gravitee-io/gravitee-api-management/master/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/resources/scripts/3.0.0/4-remove-devMode.js[/apim/3.x/mongodb/3.0.0/4-remove-devMode.js]::
 This script removes the 'devMode' parameter, since the legacy portal has been replaced.
 
-link:https://raw.githubusercontent.com/gravitee-io/gravitee-api-management/master/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/resources/scripts/3.0.0/5-remove-orphan-documentation-pages.js[/apim/3.x/mongodb/3.0.0/5-remove-orphan-documentation-pages.js]::
+link:https://gh.gravitee.io/gravitee-io/gravitee-api-management/master/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/resources/scripts/3.0.0/5-remove-orphan-documentation-pages.js[/apim/3.x/mongodb/3.0.0/5-remove-orphan-documentation-pages.js]::
 Due to a bug in a previous version of gravitee when importing APIs, orphan pages may have been created. Orphan pages are all pages with a parentId but no page with such id exists.
 In some situation, this can lead to errors when accessing portal or apis documentation.
 You may use this script to find and remove orphan pages.
 
 _Note: You can make a 'dry run' by commenting line 6 and uncommenting line 5._
 
-link:https://raw.githubusercontent.com/gravitee-io/gravitee-api-management/master/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/resources/scripts/3.0.0/6-remove-ALL-view-and-defaultView-field.js[/apim/3.x/mongodb/3.0.0/6-remove-ALL-view-and-defaultView-field.js]::
+link:https://gh.gravitee.io/gravitee-io/gravitee-api-management/master/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/resources/scripts/3.0.0/6-remove-ALL-view-and-defaultView-field.js[/apim/3.x/mongodb/3.0.0/6-remove-ALL-view-and-defaultView-field.js]::
 This script removes the 'All' *view*, since the legacy portal has been replaced and the new portal does not need this default view anymore. The script also updates existing views to remove *defaultView* field.
 
 == Upgrader

--- a/pages/apim/3.x/installation-guide/upgrades/3.0.2/README.adoc
+++ b/pages/apim/3.x/installation-guide/upgrades/3.0.2/README.adoc
@@ -10,5 +10,5 @@ Linked to this issue: https://github.com/gravitee-io/issues/issues/3843[#3843]
 
 Before running any script, please create a dump of your existing database.
 
-link:https://raw.githubusercontent.com/gravitee-io/gravitee-api-management/master/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/resources/scripts/3.0.2/1-rename-view-in-category.js[upgrades/3.x/3.0.2/mongodb/1-rename-view-in-category.js]::
+link:https://gh.gravitee.io/gravitee-io/gravitee-api-management/master/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/resources/scripts/3.0.2/1-rename-view-in-category.js[upgrades/3.x/3.0.2/mongodb/1-rename-view-in-category.js]::
 This script renames a field in 'apis' collection, rename 'views' collection, change 3 parameters, replace 'view' by 'category' in 'audits' collection and convert documentation view LINK to ctagory LINK

--- a/pages/apim/3.x/installation-guide/upgrades/3.10.1/README.adoc
+++ b/pages/apim/3.x/installation-guide/upgrades/3.10.1/README.adoc
@@ -18,5 +18,5 @@ WARNING: In future versions, others plugins & components might be renamed. Stay 
 
 Before running any script, please create a dump of your existing database.
 
-link:https://raw.githubusercontent.com/gravitee-io/gravitee-api-management/master/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/resources/scripts/3.10.1/1-upgrade-parameters-for-theme-console.js[/apim/3.x/mongodb/3.10.1/1-upgrade-parameters-for-theme-console.js]::
+link:https://gh.gravitee.io/gravitee-io/gravitee-api-management/master/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/resources/scripts/3.10.1/1-upgrade-parameters-for-theme-console.js[/apim/3.x/mongodb/3.10.1/1-upgrade-parameters-for-theme-console.js]::
 This script upgrade default value of `theme.logo` in parameters

--- a/pages/apim/3.x/installation-guide/upgrades/3.11.1/README.adoc
+++ b/pages/apim/3.x/installation-guide/upgrades/3.11.1/README.adoc
@@ -6,5 +6,5 @@
 
 Before running any script, please create a dump of your existing database.
 
-link:https://raw.githubusercontent.com/gravitee-io/gravitee-api-management/master/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/resources/scripts/3.11.1/1-event-debug-migration.js[/apim/3.x/mongodb/3.11.1/1-event-debug-migration.js]::
+link:https://gh.gravitee.io/gravitee-io/gravitee-api-management/master/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/resources/scripts/3.11.1/1-event-debug-migration.js[/apim/3.x/mongodb/3.11.1/1-event-debug-migration.js]::
 This script removes the `API_ID` property for events of type `DEBUG`.

--- a/pages/apim/3.x/installation-guide/upgrades/3.12.0/README.adoc
+++ b/pages/apim/3.x/installation-guide/upgrades/3.12.0/README.adoc
@@ -75,5 +75,5 @@ The Rest API endpoints listed below are now deprecated, and will be removed in a
 
 Before running any script, please create a dump of your existing database.
 
-link:https://raw.githubusercontent.com/gravitee-io/gravitee-api-management/master/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/resources/scripts/3.12.0/api-keys-migration.js[/apim/3.x/mongodb/3.12.0/api-keys-migration.js]::
+link:https://gh.gravitee.io/gravitee-io/gravitee-api-management/master/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/resources/scripts/3.12.0/api-keys-migration.js[/apim/3.x/mongodb/3.12.0/api-keys-migration.js]::
 This script adds *key* and *api* columns in api keys *keys* table.

--- a/pages/apim/3.x/installation-guide/upgrades/3.17.0/README.adoc
+++ b/pages/apim/3.x/installation-guide/upgrades/3.17.0/README.adoc
@@ -50,5 +50,5 @@ have been moved to the link:https://github.com/gravitee-io/gravitee-api-manageme
 
 Before running any script, please create a dump of your existing database.
 
-link:https://raw.githubusercontent.com/gravitee-io/gravitee-api-management/master/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/resources/scripts/3.17.0/api-keys-cleanup.js[/apim/3.x/mongodb/3.17.0/api-keys-cleanup.js]::
+link:https://gh.gravitee.io/gravitee-io/gravitee-api-management/master/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/resources/scripts/3.17.0/api-keys-cleanup.js[/apim/3.x/mongodb/3.17.0/api-keys-cleanup.js]::
 This script performs some cleanup on the keys collection in order to avoid issues while moving to the new model.

--- a/pages/apim/3.x/installation-guide/upgrades/3.18.0/README.adoc
+++ b/pages/apim/3.x/installation-guide/upgrades/3.18.0/README.adoc
@@ -81,7 +81,7 @@ This upgrader will run once again during APIM 3.18 startup, with dry-run mode di
 
 Before running any script, please create a dump of your existing database.
 
-link:https://raw.githubusercontent.com/gravitee-io/gravitee-api-management/master/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/resources/scripts/3.18.0/audit-set-environmentId-organizationId.js[/apim/3.x/mongodb/3.18.0/audit-set-environmentId-organizationId.js]::
+link:https://gh.gravitee.io/gravitee-io/gravitee-api-management/master/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/resources/scripts/3.18.0/audit-set-environmentId-organizationId.js[/apim/3.x/mongodb/3.18.0/audit-set-environmentId-organizationId.js]::
 This script add 'environmentId' and 'organizationId' columns in 'audits' table so audits can be associated to the right target. Creates also new indices.
-link:https://raw.githubusercontent.com/gravitee-io/gravitee-api-management/master/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/resources/scripts/3.18.0/clientRegistrationProvider-set-environmentId.js[/apim/3.x/mongodb/3.18.0/clientRegistrationProvider-set-environmentId.js]::
+link:https://gh.gravitee.io/gravitee-io/gravitee-api-management/master/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/resources/scripts/3.18.0/clientRegistrationProvider-set-environmentId.js[/apim/3.x/mongodb/3.18.0/clientRegistrationProvider-set-environmentId.js]::
 This script add 'environmentId' columns in 'client_registration_providers' table they can be associated to the right environment.

--- a/pages/apim/3.x/installation-guide/upgrades/3.3.0/README.adoc
+++ b/pages/apim/3.x/installation-guide/upgrades/3.3.0/README.adoc
@@ -6,10 +6,10 @@
 
 Before running any script, please create a dump of your existing database.
 
-link:https://raw.githubusercontent.com/gravitee-io/gravitee-api-management/master/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/resources/scripts/3.3.0/1-update-users-and-identityProviders.js[/apim/3.x/mongodb/3.3.0/1-update-users-and-identityProviders.js]::
+link:https://gh.gravitee.io/gravitee-io/gravitee-api-management/master/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/resources/scripts/3.3.0/1-update-users-and-identityProviders.js[/apim/3.x/mongodb/3.3.0/1-update-users-and-identityProviders.js]::
 This script replaces *referenceId* and *referenceType* with *organizationId* for `users` and `identity_providers` collections.
 
-link:https://raw.githubusercontent.com/gravitee-io/gravitee-api-management/master/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/resources/scripts/3.3.0/2-update-json-validation-policy-scopes.js[/apim/3.x/mongodb/3.3.0/2-update-json-validation-policy-scopes.js]::
+link:https://gh.gravitee.io/gravitee-io/gravitee-api-management/master/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/resources/scripts/3.3.0/2-update-json-validation-policy-scopes.js[/apim/3.x/mongodb/3.3.0/2-update-json-validation-policy-scopes.js]::
 This script replaces *REQUEST* and *RESPONSE* with *REQUEST_CONTENT* and *RESPONSE_CONTENT* for json-validation policy configuration in `apis` collections.
 
 

--- a/pages/apim/3.x/installation-guide/upgrades/3.4.0/README.adoc
+++ b/pages/apim/3.x/installation-guide/upgrades/3.4.0/README.adoc
@@ -6,8 +6,8 @@
 
 Before running any script, please create a dump of your existing database.
 
-link:https://raw.githubusercontent.com/gravitee-io/gravitee-api-management/master/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/resources/scripts/3.4.0/1-update-audit-to-replace-PORTAL-with_ORGANIZATION-and-ENVIRONMENT.js[/apim/3.x/mongodb/3.4.0/1-update-audit-to-replace-PORTAL-with_ORGANIZATION-and-ENVIRONMENT.js]::
+link:https://gh.gravitee.io/gravitee-io/gravitee-api-management/master/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/resources/scripts/3.4.0/1-update-audit-to-replace-PORTAL-with_ORGANIZATION-and-ENVIRONMENT.js[/apim/3.x/mongodb/3.4.0/1-update-audit-to-replace-PORTAL-with_ORGANIZATION-and-ENVIRONMENT.js]::
 This script convert PORTAL audit into ENVIRONMENT audits or ORGANIZATION audits regarding some conditions.
 
-link:https://raw.githubusercontent.com/gravitee-io/gravitee-api-management/master/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/resources/scripts/3.4.0/2-update-default-role-REVIEWER.js[/apim/3.x/mongodb/3.4.0/2-update-default-role-REVIEWER.js]::
+link:https://gh.gravitee.io/gravitee-io/gravitee-api-management/master/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/resources/scripts/3.4.0/2-update-default-role-REVIEWER.js[/apim/3.x/mongodb/3.4.0/2-update-default-role-REVIEWER.js]::
 This script add new permissions to the default REVIEWER role.

--- a/pages/apim/3.x/installation-guide/upgrades/3.5.0/README.adoc
+++ b/pages/apim/3.x/installation-guide/upgrades/3.5.0/README.adoc
@@ -73,5 +73,5 @@ You no longer have to choose between the "full" or "full-jdbc" ZIP file.
 
 Before running any script, please create a dump of your existing database.
 
-link:https://raw.githubusercontent.com/gravitee-io/gravitee-api-management/master/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/resources/scripts/3.5.0/1-duplicate-some-parameters-for-console.js[/apim/3.x/mongodb/3.5.01-duplicate-some-parameters-for-console.js]::
+link:https://gh.gravitee.io/gravitee-io/gravitee-api-management/master/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/resources/scripts/3.5.0/1-duplicate-some-parameters-for-console.js[/apim/3.x/mongodb/3.5.01-duplicate-some-parameters-for-console.js]::
 This script duplicates some parameters for the console to have different behaviors between portal and console. It also modifies the _id of each mongo document to add referenceId and referenceType.

--- a/pages/apim/3.x/installation-guide/upgrades/3.5.14/README.adoc
+++ b/pages/apim/3.x/installation-guide/upgrades/3.5.14/README.adoc
@@ -6,7 +6,7 @@
 
 Before running any script, please create a dump of your existing database.
 
-link:https://raw.githubusercontent.com/gravitee-io/gravitee-api-management/master/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/resources/scripts/3.5.14/1-fix-cors-env-vars.js[/apim/3.x/mongodb/3.5.14/1-fix-cors-env-vars.js]::
+link:https://gh.gravitee.io/gravitee-io/gravitee-api-management/master/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/resources/scripts/3.5.14/1-fix-cors-env-vars.js[/apim/3.x/mongodb/3.5.14/1-fix-cors-env-vars.js]::
 This script migrate CORS environment variables for portal and console. (See below).
 
 == Breaking Changes

--- a/pages/apim/3.x/installation-guide/upgrades/3.5.2/README.adoc
+++ b/pages/apim/3.x/installation-guide/upgrades/3.5.2/README.adoc
@@ -6,6 +6,6 @@
 
 Before running any script, please create a dump of your existing database.
 
-link:https://raw.githubusercontent.com/gravitee-io/gravitee-api-management/master/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/resources/scripts/3.5.2/1-add-DEFAULT-referenceId-in-memberships.js[/apim/3.x/mongodb/3.5.2/1-add-DEFAULT-referenceId-in-memberships.js]::
+link:https://gh.gravitee.io/gravitee-io/gravitee-api-management/master/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/resources/scripts/3.5.2/1-add-DEFAULT-referenceId-in-memberships.js[/apim/3.x/mongodb/3.5.2/1-add-DEFAULT-referenceId-in-memberships.js]::
 This script add the "DEFAULT" `referenceId` for memberships with `null` one. This bug impacts users created when using social authentication since version 3.5.0.
 

--- a/pages/apim/3.x/installation-guide/upgrades/3.7.0/README.adoc
+++ b/pages/apim/3.x/installation-guide/upgrades/3.7.0/README.adoc
@@ -29,7 +29,7 @@ This script rename all the collections adding the `prefix` and `rateLimitPrefix`
 For the following steps, we admit you choose this prefix: prefix_
 
 1. Modify `gravitee.yml` to configure `management.mongodb.prefix` and `ratelimit.mongodb.prefix` if needed.
-2. Run the following script to rename your collections: link:https://raw.githubusercontent.com/gravitee-io/gravitee-api-management/master/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/resources/scripts/3.7.0/1-rename-collections-with-prefix.js[/apim/3.x/mongodb/3.7.0/1-rename-collections-with-prefix.js]
+2. Run the following script to rename your collections: link:https://gh.gravitee.io/gravitee-io/gravitee-api-management/master/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/resources/scripts/3.7.0/1-rename-collections-with-prefix.js[/apim/3.x/mongodb/3.7.0/1-rename-collections-with-prefix.js]
 3. Run your instances!
 
 === JDBC

--- a/pages/apim/3.x/installation-guide/upgrades/3.8.0/README.adoc
+++ b/pages/apim/3.x/installation-guide/upgrades/3.8.0/README.adoc
@@ -6,5 +6,5 @@
 
 Before running any script, please create a dump of your existing database.
 
-link:https://raw.githubusercontent.com/gravitee-io/gravitee-api-management/master/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/resources/scripts/3.8.0/1-page-acl-migration.js[/apim/3.x/mongodb/3.8.0/1-page-acl-migration.js]::
+link:https://gh.gravitee.io/gravitee-io/gravitee-api-management/master/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/resources/scripts/3.8.0/1-page-acl-migration.js[/apim/3.x/mongodb/3.8.0/1-page-acl-migration.js]::
 This script replaces *excluded_groups* by *visibility*, *excludedAccessControls* and *accessControls* collection.

--- a/pages/apim/3.x/installation-guide/upgrades/3.9.0/README.adoc
+++ b/pages/apim/3.x/installation-guide/upgrades/3.9.0/README.adoc
@@ -38,8 +38,8 @@ If you are using these permissions, please update them for the scope `ORGANIZATI
 
 Before running any script, please create a dump of your existing database.
 
-link:https://raw.githubusercontent.com/gravitee-io/gravitee-api-management/master/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/resources/scripts/3.9.0/1-tags-and-tenants-migration.js[/apim/3.x/mongodb/3.9.0/1-tags-and-tenants-migration.js]::
+link:https://gh.gravitee.io/gravitee-io/gravitee-api-management/master/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/resources/scripts/3.9.0/1-tags-and-tenants-migration.js[/apim/3.x/mongodb/3.9.0/1-tags-and-tenants-migration.js]::
 This script adds referenceId set to 'DEFAULT' and referenceType set to 'ORGANIZATION' to tags, tenants and entrypoint collections.
 
-link:https://raw.githubusercontent.com/gravitee-io/gravitee-api-management/master/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/resources/scripts/3.9.0/2-events-migration.js[/apim/3.x/mongodb/3.9.0/2-events-migration.js]::
+link:https://gh.gravitee.io/gravitee-io/gravitee-api-management/master/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/resources/scripts/3.9.0/2-events-migration.js[/apim/3.x/mongodb/3.9.0/2-events-migration.js]::
 This script modifies events, so an event can be linked to more than one environment.


### PR DESCRIPTION
**Description**

Use our internal DNS to target mongo scripts.
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://graviteedocs.blob.core.windows.net/update-mongodb-links/index.html)
<!-- UI placeholder end -->
