### PR TITLE
[APIM] Add changelog for new 3.19.10 release

### DIFF
--- a/pages/apim/3.x/changelog/changelog-3.19.adoc
+++ b/pages/apim/3.x/changelog/changelog-3.19.adoc
@@ -13,6 +13,36 @@ For upgrade instructions, please refer to https://docs.gravitee.io/apim/3.x/apim
 
 // <DO NOT REMOVE THIS COMMENT - ANCHOR FOR FUTURE RELEASES>
  
+== APIM - 3.19.10 (2023-03-31)
+
+=== Gateway
+
+* Consumer response logs are missing when using the Jupiter engine https://github.com/gravitee-io/issues/issues/8942[#8942]
+* Chunk corruption with TLS and HTTP 1.1  https://github.com/gravitee-io/issues/issues/8956[#8956]
+* Random 503 error when using {#properties['backend']} on endpoint target https://github.com/gravitee-io/issues/issues/8959[#8959]
+* Debug mode not working with ssl and haproxy https://github.com/gravitee-io/issues/issues/8984[#8984]
+
+=== API
+
+* Response from the request "Attach a media to a portal page" does not give all data like in the documentation https://github.com/gravitee-io/issues/issues/6787[#6787]
+* Sending notifications is not possible when there are two subscriptions to a single application https://github.com/gravitee-io/issues/issues/8939[#8939]
+* All API displayed as out of sync even if no change was done https://github.com/gravitee-io/issues/issues/8954[#8954]
+* Data lost when upgrading to 3.18+ with JDBC database https://github.com/gravitee-io/issues/issues/8980[#8980]
+* API documentation page import impossible using Bitbucket reference  https://github.com/gravitee-io/issues/issues/8985[#8985]
+
+=== Console
+
+* Options of `gv-select` not always visible or correctly placed https://github.com/gravitee-io/issues/issues/8348[#8348]
+* Not possible to remove General conditions from a plan https://github.com/gravitee-io/issues/issues/8465[#8465]
+* Proxy fields not disabled when System proxy activated in endpoint configuration https://github.com/gravitee-io/issues/issues/8590[#8590]
+* Dashboard shows all APIs stopped when all APIs are started https://github.com/gravitee-io/issues/issues/8760[#8760]
+
+=== Other
+
+* Policy SSL Enforcement can be configured with invalid DN https://github.com/gravitee-io/issues/issues/6457[#6457]
+* XMLtoJSON policy does not execute based on Content-Type header value https://github.com/gravitee-io/issues/issues/8953[#8953]
+
+ 
 == APIM - 3.19.9 (2023-03-17)
 
 === Gateway


### PR DESCRIPTION

# New APIM version 3.19.10 has been released
📝 You can modify the changelog template online [here](https://github.com/gravitee-io/gravitee-docs/edit/release-apim-3.19.10/pages/apim/3.x/changelog/changelog-3.19.adoc)

Here is some information to help with the writing:

## Pull requests
<details>
  <summary>See all Pull Requests</summary>

### [fix: make debug mode work with ssl or haproxy enabled [3484]](https://github.com/gravitee-io/gravitee-api-management/pull/3484)
- fix: make debug mode work with ssl or haproxy enabled
### [Bump `@gravitee/ui-components` to `3.38.10` [3498]](https://github.com/gravitee-io/gravitee-api-management/pull/3498)
- fix: bump `@gravitee/ui-components` to `3.38.10`
### [Remove definition context from api history - 3.19.x [3474]](https://github.com/gravitee-io/gravitee-api-management/pull/3474)
- fix: delete definition context from api history
### [fix: remove use of `ApiRepository.findAll` - 3.19.x [3466]](https://github.com/gravitee-io/gravitee-api-management/pull/3466)
- fix: remove use of `ApiRepository.findAll`
### [Exclude Flow Ids from API Sync check - 3.19.x [3456]](https://github.com/gravitee-io/gravitee-api-management/pull/3456)
- fix: allow use of personal token on the Portal API
### [Handle application with no group when sending notification - 3.19.x [3413]](https://github.com/gravitee-io/gravitee-api-management/pull/3413)
- fix: handle application with no group when sending notification
### [Do not throw when sending notif to app owner with multiple subscriptions - 3.19.x [3405]](https://github.com/gravitee-io/gravitee-api-management/pull/3405)
- fix: bump `policy-regex-threat-protection` to `1.3.3`
- fix: do not throw when sending notif to app owner with multiple subscription to the same API
### [fix: match documentation and implementation for attach media api - 3.19.x [3389]](https://github.com/gravitee-io/gravitee-api-management/pull/3389)
- fix: match documentation and implementation for attach media api
### [Bump dependencies - 3.19.x [3395]](https://github.com/gravitee-io/gravitee-api-management/pull/3395)
- fix: bump `gravitee-policy-ssl-enforcement` to `1.2.2`
- fix: bump `gravitee-connector-http` to `2.1.3`
### [Use ApiKeyAuthHandler when ApiKey is provided but invalid [3299]](https://github.com/gravitee-io/gravitee-api-management/pull/3299)
- fix: use ApiKeyAuthHandler when ApiKey is provided but invalid
### [Properly select series labels in pie chart - 3.19.x [3382]](https://github.com/gravitee-io/gravitee-api-management/pull/3382)
- fix: properly select series' labels in pie chart
### [Update `connector-http` to `2.1.2` - 3.19.x [3366]](https://github.com/gravitee-io/gravitee-api-management/pull/3366)
- fix: update `connector-http` to `2.1.2`
### [Add an empty option when selecting the general condition of a plan - 3.19.x [3363]](https://github.com/gravitee-io/gravitee-api-management/pull/3363)
- fix: add an empty option when selecting general condition of a plan
### [fix: add client response in logs with jupiter - 3.19.x [3351]](https://github.com/gravitee-io/gravitee-api-management/pull/3351)
- fix: add client response in logs with jupiter
- fix: add client response in logs with jupiter
### [Update `policy-xml-json` to `1.8.2` - 3.19.x [3357]](https://github.com/gravitee-io/gravitee-api-management/pull/3357)
- fix: update `policy-xml-json` to `1.8.2`

</details>

## Jira issues

[See all Jira issues for 3.19.x version](https://gravitee.atlassian.net/jira/software/c/projects/APIM/issues/?jql=project%20%3D%20%22APIM%22%20and%20fixVersion%20%3D%203.19.10%20and%20status%20%3D%20Done%20ORDER%20BY%20created%20DESC)
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://graviteedocs.blob.core.windows.net/release-apim-3-19-10/index.html)
<!-- UI placeholder end -->
