### PR TITLE
[APIM] Add changelog for new 3.18.21 release

### DIFF
--- a/pages/apim/3.x/changelog/changelog-3.18.adoc
+++ b/pages/apim/3.x/changelog/changelog-3.18.adoc
@@ -13,6 +13,40 @@ For upgrade instructions, please refer to https://docs.gravitee.io/apim/3.x/apim
 
 // <DO NOT REMOVE THIS COMMENT - ANCHOR FOR FUTURE RELEASES>
  
+== APIM - 3.18.21 (2023-03-31)
+
+=== Gateway
+
+* Gateway timeout is not logged when API is called by another API https://github.com/gravitee-io/issues/issues/8941[#8941]
+* Health-check fails if endpoint host contains an underscore https://github.com/gravitee-io/issues/issues/8946[#8946]
+* Chunk corruption with TLS and HTTP 1.1  https://github.com/gravitee-io/issues/issues/8956[#8956]
+* Random 503 error when using {#properties['backend']} on endpoint target https://github.com/gravitee-io/issues/issues/8959[#8959]
+* Debug mode not working with ssl and haproxy https://github.com/gravitee-io/issues/issues/8984[#8984]
+
+=== API
+
+* Response from the request "Attach a media to a portal page" does not give all data like in the documentation https://github.com/gravitee-io/issues/issues/6787[#6787]
+* Search by payload does not work properly with special characters https://github.com/gravitee-io/issues/issues/8470[#8470]
+* Sending notifications is not possible when there are two subscriptions to a single application https://github.com/gravitee-io/issues/issues/8939[#8939]
+* All API displayed as out of sync even if no change was done https://github.com/gravitee-io/issues/issues/8954[#8954]
+* Data lost when upgrading to 3.18+ with JDBC database https://github.com/gravitee-io/issues/issues/8980[#8980]
+* API documentation page import impossible using Bitbucket reference  https://github.com/gravitee-io/issues/issues/8985[#8985]
+
+=== Console
+
+* Options of `gv-select` not always visible or correctly placed https://github.com/gravitee-io/issues/issues/8348[#8348]
+* Not possible to remove General conditions from a plan https://github.com/gravitee-io/issues/issues/8465[#8465]
+* Transfer ownership of API does not automatically display current members https://github.com/gravitee-io/issues/issues/8516[#8516]
+* Proxy fields not disabled when System proxy activated in endpoint configuration https://github.com/gravitee-io/issues/issues/8590[#8590]
+* Dashboard shows all APIs stopped when all APIs are started https://github.com/gravitee-io/issues/issues/8760[#8760]
+
+=== Other
+
+* Policy SSL Enforcement can be configured with invalid DN https://github.com/gravitee-io/issues/issues/6457[#6457]
+* Email notifier not handling properly newline in alert body https://github.com/gravitee-io/issues/issues/8752[#8752]
+* XMLtoJSON policy does not execute based on Content-Type header value https://github.com/gravitee-io/issues/issues/8953[#8953]
+
+ 
 == APIM - 3.18.20 (2023-03-10)
 
 === Gateway


### PR DESCRIPTION

# New APIM version 3.18.21 has been released
📝 You can modify the changelog template online [here](https://github.com/gravitee-io/gravitee-docs/edit/release-apim-3.18.21/pages/apim/3.x/changelog/changelog-3.18.adoc)

Here is some information to help with the writing:

## Pull requests
<details>
  <summary>See all Pull Requests</summary>

### [fix: make debug mode work with ssl or haproxy enabled [3482]](https://github.com/gravitee-io/gravitee-api-management/pull/3482)
- fix: make debug mode work with ssl or haproxy enabled
### [Bump `@gravitee/ui-components` to `3.38.10` [3496]](https://github.com/gravitee-io/gravitee-api-management/pull/3496)
- fix: bump `@gravitee/ui-components` to `3.38.10`
### [Remove definition context from api history [3471]](https://github.com/gravitee-io/gravitee-api-management/pull/3471)
- fix: delete definition context from api history
### [fix: remove use of `ApiRepository.findAll` [3461]](https://github.com/gravitee-io/gravitee-api-management/pull/3461)
- fix: remove use of `ApiRepository.findAll`
### [Exclude Flow Ids from API Sync check [3450]](https://github.com/gravitee-io/gravitee-api-management/pull/3450)
- fix: allow use of personal token on the Portal API
### [Handle application with no group when sending notification [3409]](https://github.com/gravitee-io/gravitee-api-management/pull/3409)
- fix: handle application with no group when sending notification
### [Do not throw when sending notif to app owner with multiple subscriptions [3401]](https://github.com/gravitee-io/gravitee-api-management/pull/3401)
- fix: bump `policy-regex-threat-protection` to `1.3.3`
- fix: do not throw when sending notif to app owner with multiple subscription to the same API
### [Bump dependencies [3390]](https://github.com/gravitee-io/gravitee-api-management/pull/3390)
- fix: bump `gravitee-policy-ssl-enforcement` to `1.2.2`
- fix: bump `gravitee-connector-http` to `2.1.3`
### [fix: match documentation and implementation for attach media api [3384]](https://github.com/gravitee-io/gravitee-api-management/pull/3384)
- fix: match documentation and implementation for attach media api
### [Properly select series labels in pie chart [3377]](https://github.com/gravitee-io/gravitee-api-management/pull/3377)
- fix: properly select series' labels in pie chart
### [Update `connector-http` to `2.1.2` [3360]](https://github.com/gravitee-io/gravitee-api-management/pull/3360)
- fix: update `connector-http` to `2.1.2`
### [Add an empty option when selecting the general condition of a plan [3361]](https://github.com/gravitee-io/gravitee-api-management/pull/3361)
- fix: add an empty option when selecting general condition of a plan
### [Update `policy-xml-json` to `1.8.2` [3353]](https://github.com/gravitee-io/gravitee-api-management/pull/3353)
- fix: update `policy-xml-json` to `1.8.2`
### [fix: bump notifier-api & notifier email [3311]](https://github.com/gravitee-io/gravitee-api-management/pull/3311)
- fix: bump notifier-api & notifier email
### [Allow underscore in hostname for HealthCheck service - 3.18.x [3304]](https://github.com/gravitee-io/gravitee-api-management/pull/3304)
- fix: allow underscore in hostname
### [fix: bump elastic reporter to 3.12.5 [3305]](https://github.com/gravitee-io/gravitee-api-management/pull/3305)
- fix: bump elastic reporter to 3.12.5
### [Display list of API members in the transfer ownership screen [3295]](https://github.com/gravitee-io/gravitee-api-management/pull/3295)
- fix: display list of API members in the transfer ownership screen
### [fix: log all timeouts when chaining calls [3280]](https://github.com/gravitee-io/gravitee-api-management/pull/3280)
- fix: log all timeouts when chaining calls
### [fix: escape uri components in log queries [3272]](https://github.com/gravitee-io/gravitee-api-management/pull/3272)
- fix: escape uri components in log queries

</details>

## Jira issues

[See all Jira issues for 3.18.x version](https://gravitee.atlassian.net/jira/software/c/projects/APIM/issues/?jql=project%20%3D%20%22APIM%22%20and%20fixVersion%20%3D%203.18.21%20and%20status%20%3D%20Done%20ORDER%20BY%20created%20DESC)
