### PR TITLE
fix(am): addition of migration note for 4.0 about MongoDB indexes

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -124,9 +124,9 @@ products:
     ee:
       version: 3.20.0
   am:
-    version: 3.20.0
+    version: 4.0.0
     ee:
-      version: 3.20.0
+      version: 4.0.0
   ae:
     version: 2.0.0
     name: Gravitee.io Alert Engine (AE)

--- a/_data/sidebars/am_3_x_sidebar.yml
+++ b/_data/sidebars/am_3_x_sidebar.yml
@@ -677,6 +677,9 @@ entries:
             output: web
             url: /am/current/am_breaking_changes.html
             type: homepage
+          - title: Breaking changes in 4.0
+            output: web
+            url: /am/current/am_breaking_changes_4.0.html
           - title: Breaking changes in 3.20
             output: web
             url: /am/current/am_breaking_changes_3.20.html

--- a/pages/am/3.x/breaking-changes/breaking-changes-4.0.adoc
+++ b/pages/am/3.x/breaking-changes/breaking-changes-4.0.adoc
@@ -1,0 +1,11 @@
+= Breaking changes in 4.0
+:page-sidebar: am_3_x_sidebar
+:page-permalink: am/current/am_breaking_changes_4.0.html
+:page-folder: am/installation-guide
+:page-layout: am
+
+NOTE: To take advantage of these new features and incorporate these breaking changes, **use the migration guide available link:{{ '/am/current/am_installguide_migration.html' | relative_url }}[here]**.
+
+== MongoDB indexes name
+
+Starting from AM 4.0, the MongoDB indexes are now named using the first letter of the fields that compose the index. This change will allow to manage automatically indexes creation on DocumentDB. This change requires the execution of a MongoDB script to delete AM indexes and recreate them. Please see  **the migration guide available link:{{ '/am/current/am_installguide_migration.html' | relative_url }}[here]**.

--- a/pages/am/3.x/breaking-changes/breaking-changes.adoc
+++ b/pages/am/3.x/breaking-changes/breaking-changes.adoc
@@ -6,6 +6,7 @@
 
 This section outlines the changes you should consider when migrating your application from one version of Gravitee.io Access Management to another.
 
+* link:{{ '/am/current/am_breaking_changes_4.0.html' | relative_url }}[Breaking changes in 4.0]
 * link:{{ '/am/current/am_breaking_changes_3.20.html' | relative_url }}[Breaking changes in 3.20]
 * link:{{ '/am/current/am_breaking_changes_3.19.html' | relative_url }}[Breaking changes in 3.19]
 * link:{{ '/am/current/am_breaking_changes_3.18.html' | relative_url }}[Breaking changes in 3.18]

--- a/pages/am/3.x/installation-guide/installation-guide-migration.adoc
+++ b/pages/am/3.x/installation-guide/installation-guide-migration.adoc
@@ -8,6 +8,15 @@ WARNING: If you plan to skip versions when you upgrade, ensure that you read the
 
 WARNING: Make sure to run scripts on the correct database since `gravitee-am` is not always the default database! Check your db name by running `show dbs`.
 
+== Upgrade to 4.0.0
+
+NOTE: For more information about the breaking changes of this version, see link:{{ '/am/current/am_breaking_changes_4.0.html' | relative_url }}[Breaking changes in 4.0]
+
+=== MongoDB indexes
+
+Starting from AM 4.0, the MongoDB indexes are now named using the first letter of the fields that compose the index. This change will allow to manage automatically indexes creation on DocumentDB. Before starting the Management API service, please execute the following link:https://gh.gravitee.io/gravitee-io/gravitee-access-management/blob/master/gravitee-am-repository/gravitee-am-repository-mongodb/src/main/resources/scripts/create-index.js[script] to delete indexes and recreate them with the right convention.
+
+
 == Upgrade to 3.20
 
 NOTE: For more information about the breaking changes of this version, see link:{{ '/am/current/am_breaking_changes_3.20.html' | relative_url }}[Breaking changes in 3.20]


### PR DESCRIPTION
related-to AM-63

<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://graviteedocs.blob.core.windows.net/am-63-add-migrationguide/index.html)
<!-- UI placeholder end -->
