### PR TITLE
fix: Typo in the OpenAPI spec extension for the 3.20 of the portal API

### DIFF
--- a/apim/3.x/portal-api/3.20/index.html
+++ b/apim/3.x/portal-api/3.20/index.html
@@ -3,7 +3,7 @@ layout: api
 ---
 
 <redoc
-  spec-url='{{ "openapi.yml" }}'
+  spec-url='{{ "openapi.yaml" }}'
   native-scrollbars="true"
   scroll-y-offset="50"
   min-character-length-to-init-search="1"


### PR DESCRIPTION

<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://graviteedocs.blob.core.windows.net/fix-openapi-link/index.html)
<!-- UI placeholder end -->
