### PR TITLE
[APIM] Add changelog for new 3.19.11 release

### DIFF
--- a/pages/apim/3.x/changelog/changelog-3.19.adoc
+++ b/pages/apim/3.x/changelog/changelog-3.19.adoc
@@ -13,6 +13,29 @@ For upgrade instructions, please refer to https://docs.gravitee.io/apim/3.x/apim
 
 // <DO NOT REMOVE THIS COMMENT - ANCHOR FOR FUTURE RELEASES>
  
+== APIM - 3.19.11 (2023-04-07)
+
+=== API
+
+* Default API role defined at the organization level is overriding the default group member role https://github.com/gravitee-io/issues/issues/7362[#7362]
+
+=== Console
+
+* Non-admin user cannot transfer ownership of application https://github.com/gravitee-io/issues/issues/8455[#8455]
+* Not able to open Application and API in a new tab by right-clicking their names https://github.com/gravitee-io/issues/issues/8589[#8589]
+* ID_token_hint missing from console logout leading to errors https://github.com/gravitee-io/issues/issues/8998[#8998]
+
+=== Portal
+
+* Paging issues with members of an application https://github.com/gravitee-io/issues/issues/8582[#8582]
+* Cannot use PKCE authentication on Swagger doc page https://github.com/gravitee-io/issues/issues/9005[#9005]
+
+=== Other
+
+* Stats pie widget not matching the colors and labels defined in config https://github.com/gravitee-io/issues/issues/8989[#8989]
+* When migration is used on paths based API no redirection to designer studio is done https://github.com/gravitee-io/issues/issues/8994[#8994]
+
+ 
 == APIM - 3.19.10 (2023-03-31)
 
 === Gateway


### PR DESCRIPTION

# New APIM version 3.19.11 has been released
📝 You can modify the changelog template online [here](https://github.com/gravitee-io/gravitee-docs/edit/release-apim-3.19.11/pages/apim/3.x/changelog/changelog-3.19.adoc)

Here is some information to help with the writing:

## Pull requests
<details>
  <summary>See all Pull Requests</summary>

### [fix: use group default roles if exists when adding members - 3.19.x [3576]](https://github.com/gravitee-io/gravitee-api-management/pull/3576)
- fix: use group default roles if exists when adding members
### [feat: add option to use pkce authent in swagger doc page - 3.19.x [3580]](https://github.com/gravitee-io/gravitee-api-management/pull/3580)
- feat: add option to use pkce authent in swagger doc page
### [feat: add option to use pkce authent in swagger doc page [3570]](https://github.com/gravitee-io/gravitee-api-management/pull/3570)
- feat: add option to use pkce authent in swagger doc page
### [fix: use group default roles if exists when adding members [3566]](https://github.com/gravitee-io/gravitee-api-management/pull/3566)
- fix: use group default roles if exists when adding members
### [Apim 1401 - 3.19.x [3563]](https://github.com/gravitee-io/gravitee-api-management/pull/3563)
- fix: set id_token_hint on logout request when user authenticated with OIDC provider
### [Apim 1401 [3553]](https://github.com/gravitee-io/gravitee-api-management/pull/3553)
- fix: set id_token_hint on logout request when user authenticated with OIDC provider
### [fix: use the right route to redirect to studio - 3.19.x [3548]](https://github.com/gravitee-io/gravitee-api-management/pull/3548)
- fix: use the right route to redirect to studio
### [fix: use the right route to redirect to studio [3544]](https://github.com/gravitee-io/gravitee-api-management/pull/3544)
- fix: use the right route to redirect to studio
### [Apply some magic default values to ensure pie chart graphs display the correct colors and labels - 3.19.x [3543]](https://github.com/gravitee-io/gravitee-api-management/pull/3543)
- fix: apply some magic values to ensure pie chart graph display the correct colors and labels
### [Use correct permission to display transfer app ownership section - 3.19.x [3539]](https://github.com/gravitee-io/gravitee-api-management/pull/3539)
- fix: use correct permission to display transfer app ownership section
### [Apply some magic default values to ensure pie chart graphs display the correct colors and labels [3525]](https://github.com/gravitee-io/gravitee-api-management/pull/3525)
- fix: apply some magic values to ensure pie chart graph display the correct colors and labels
### [Use correct permission to display transfer app ownership section [3523]](https://github.com/gravitee-io/gravitee-api-management/pull/3523)
- fix: use correct permission to display transfer app ownership section
### [Update some dependencies to mitigate vulnerability - 3.19.x [3530]](https://github.com/gravitee-io/gravitee-api-management/pull/3530)
- fix(deps): update nimbus-jose-jwt to 9.31
### [Apim 900 open api in new tab 3 19 [3534]](https://github.com/gravitee-io/gravitee-api-management/pull/3534)
- feat: enable open application in new tab
- feat: allow navigation to api details with a href
### [Update some dependencies to mitigate vulnerability [3.18.x] [3497]](https://github.com/gravitee-io/gravitee-api-management/pull/3497)
- fix(deps): update moment to 2.29.4
- fix(deps): remove outdated jackson-mapper-asl
- fix(deps): update nimbus-jose-jwt to 9.31
### [fix: make debug mode work with ssl or haproxy enabled [3482]](https://github.com/gravitee-io/gravitee-api-management/pull/3482)
- fix: make debug mode work with ssl or haproxy enabled
### [Bump `@gravitee/ui-components` to `3.38.10` [3496]](https://github.com/gravitee-io/gravitee-api-management/pull/3496)
- fix: bump `@gravitee/ui-components` to `3.38.10`
### [Remove definition context from api history [3471]](https://github.com/gravitee-io/gravitee-api-management/pull/3471)
- fix: delete definition context from api history
### [fix: remove use of `ApiRepository.findAll` [3461]](https://github.com/gravitee-io/gravitee-api-management/pull/3461)
- fix: remove use of `ApiRepository.findAll`
### [Exclude Flow Ids from API Sync check [3450]](https://github.com/gravitee-io/gravitee-api-management/pull/3450)
- fix: allow use of personal token on the Portal API
### [Handle application with no group when sending notification [3409]](https://github.com/gravitee-io/gravitee-api-management/pull/3409)
- fix: handle application with no group when sending notification
### [Do not throw when sending notif to app owner with multiple subscriptions [3401]](https://github.com/gravitee-io/gravitee-api-management/pull/3401)
- fix: bump `policy-regex-threat-protection` to `1.3.3`
- fix: do not throw when sending notif to app owner with multiple subscription to the same API
### [Bump dependencies [3390]](https://github.com/gravitee-io/gravitee-api-management/pull/3390)
- fix: bump `gravitee-policy-ssl-enforcement` to `1.2.2`
- fix: bump `gravitee-connector-http` to `2.1.3`
### [fix: match documentation and implementation for attach media api [3384]](https://github.com/gravitee-io/gravitee-api-management/pull/3384)
- fix: match documentation and implementation for attach media api
### [Properly select series labels in pie chart [3377]](https://github.com/gravitee-io/gravitee-api-management/pull/3377)
- fix: properly select series' labels in pie chart
### [Update `connector-http` to `2.1.2` [3360]](https://github.com/gravitee-io/gravitee-api-management/pull/3360)
- fix: update `connector-http` to `2.1.2`
### [Add an empty option when selecting the general condition of a plan [3361]](https://github.com/gravitee-io/gravitee-api-management/pull/3361)
- fix: add an empty option when selecting general condition of a plan
### [Update `policy-xml-json` to `1.8.2` [3353]](https://github.com/gravitee-io/gravitee-api-management/pull/3353)
- fix: update `policy-xml-json` to `1.8.2`
### [fix: bump notifier-api & notifier email [3311]](https://github.com/gravitee-io/gravitee-api-management/pull/3311)
- fix: bump notifier-api & notifier email
### [Allow underscore in hostname for HealthCheck service - 3.18.x [3304]](https://github.com/gravitee-io/gravitee-api-management/pull/3304)
- fix: allow underscore in hostname
### [fix: bump elastic reporter to 3.12.5 [3305]](https://github.com/gravitee-io/gravitee-api-management/pull/3305)
- fix: bump elastic reporter to 3.12.5
### [Display list of API members in the transfer ownership screen [3295]](https://github.com/gravitee-io/gravitee-api-management/pull/3295)
- fix: display list of API members in the transfer ownership screen

</details>

## Jira issues

[See all Jira issues for 3.19.x version](https://gravitee.atlassian.net/jira/software/c/projects/APIM/issues/?jql=project%20%3D%20%22APIM%22%20and%20fixVersion%20%3D%203.19.11%20and%20status%20%3D%20Done%20ORDER%20BY%20created%20DESC)
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://graviteedocs.blob.core.windows.net/release-apim-3-19-11/index.html)
<!-- UI placeholder end -->
