### PR TITLE
fix: Update default gravitee.yml conf link to use the Gravitee DNS

### DIFF
--- a/pages/apim/3.x/installation-guide/configuration/gateway/installation-guide-gateway-configuration.adoc
+++ b/pages/apim/3.x/installation-guide/configuration/gateway/installation-guide-gateway-configuration.adoc
@@ -396,5 +396,5 @@ You can configure various default properties of APIM Gateway in your `gravitee.y
 
 [source,yaml]
 ----
-include::https://raw.githubusercontent.com/gravitee-io/gravitee-api-management/{{ site.products.apim._3x.version }}/gravitee-apim-gateway/gravitee-apim-gateway-standalone/gravitee-apim-gateway-standalone-distribution/src/main/resources/config/gravitee.yml[]
+include::https://gh.gravitee.io/gravitee-io/gravitee-api-management/{{ site.products.apim._3x.version }}/gravitee-apim-gateway/gravitee-apim-gateway-standalone/gravitee-apim-gateway-standalone-distribution/src/main/resources/config/gravitee.yml[]
 ----


### PR DESCRIPTION

<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://graviteedocs.blob.core.windows.net/fix-default-conf-link/index.html)
<!-- UI placeholder end -->
