### PR TITLE
[APIM] Add changelog for new 3.18.23 release

### DIFF
--- a/pages/apim/3.x/changelog/changelog-3.18.adoc
+++ b/pages/apim/3.x/changelog/changelog-3.18.adoc
@@ -13,6 +13,36 @@ For upgrade instructions, please refer to https://docs.gravitee.io/apim/3.x/apim
 
 // <DO NOT REMOVE THIS COMMENT - ANCHOR FOR FUTURE RELEASES>
  
+== APIM - 3.18.23 (2023-04-28)
+
+=== Gateway
+
+* OutOfMemory when calling the Prometheus endpoint https://github.com/gravitee-io/issues/issues/8976[#8976]
+
+=== API
+
+* API Search returns a lexical error when using `/` https://github.com/gravitee-io/issues/issues/8753[#8753]
+* No default role applied for users if a Condition for a Role Mapping is evaluated as false https://github.com/gravitee-io/issues/issues/8971[#8971]
+* Plan policies are lost during API migration to design studio https://github.com/gravitee-io/issues/issues/8981[#8981]
+* Dynamic properties are not working on APIs not in DEFAULT environment https://github.com/gravitee-io/issues/issues/9018[#9018]
+* Improve API v1 (Path based) to API v2 (Flow based) conversion https://github.com/gravitee-io/issues/issues/9036[#9036]
+* Pentest - 2023 - Q1 - XSS via Markdown https://github.com/gravitee-io/issues/issues/undefined[#undefined]
+
+=== Console
+
+* "Export as CSV" on Subscriptions only export displayed values https://github.com/gravitee-io/issues/issues/8965[#8965]
+* Unable to filter API's logs by application name https://github.com/gravitee-io/issues/issues/8995[#8995]
+
+=== Portal
+
+* API Picture not displayed on Application page https://github.com/gravitee-io/issues/issues/8749[#8749]
+
+=== Other
+
+* Request Validation policy hangs in certain conditions https://github.com/gravitee-io/issues/issues/8347[#8347]
+* Policy SSL Enforcement too restrictive regex https://github.com/gravitee-io/issues/issues/9029[#9029]
+
+ 
 == APIM - 3.18.22 (2023-04-21)
 
 === API

--- a/pages/apim/3.x/changelog/changelog-3.18.adoc
+++ b/pages/apim/3.x/changelog/changelog-3.18.adoc
@@ -26,7 +26,6 @@ For upgrade instructions, please refer to https://docs.gravitee.io/apim/3.x/apim
 * Plan policies are lost during API migration to design studio https://github.com/gravitee-io/issues/issues/8981[#8981]
 * Dynamic properties are not working on APIs not in DEFAULT environment https://github.com/gravitee-io/issues/issues/9018[#9018]
 * Improve API v1 (Path based) to API v2 (Flow based) conversion https://github.com/gravitee-io/issues/issues/9036[#9036]
-* Pentest - 2023 - Q1 - XSS via Markdown https://github.com/gravitee-io/issues/issues/undefined[#undefined]
 
 === Console
 
@@ -73,7 +72,7 @@ For upgrade instructions, please refer to https://docs.gravitee.io/apim/3.x/apim
 
 * Cannot retrieve scheme (http/https) and port in Groovy policy, missing getters... https://github.com/gravitee-io/issues/issues/9007[#9007]
 * API properties can not be accessed in Javascript Policy https://github.com/gravitee-io/issues/issues/9010[#9010]
-* User wrongly see API task in tasks list https://github.com/gravitee-io/issues/issues/undefined[#undefined]
+* User wrongly see API task in tasks list
 
  
 == APIM - 3.18.21 (2023-03-31)


### PR DESCRIPTION

# New APIM version 3.18.23 has been released
📝 You can modify the changelog template online [here](https://github.com/gravitee-io/gravitee-docs/edit/release-apim-3.18.23/pages/apim/3.x/changelog/changelog-3.18.adoc)

Here is some information to help with the writing:

## Pull requests
<details>
  <summary>See all Pull Requests</summary>

### [fix: compute application apis subscribers links [3822]](https://github.com/gravitee-io/gravitee-api-management/pull/3822)
- fix: compute application apis subscribers links
### [Bump policies and gravitee-node [3813]](https://github.com/gravitee-io/gravitee-api-management/pull/3813)
- fix: bump `gravitee-policy-request-validation` to `1.13.1`
- fix: bump `gravitee-policy-ssl-enforcement` to `1.2.3`
- fix: bump `gravitee-node` to `1.24.7`
### [remove author picture from api promotion [3805]](https://github.com/gravitee-io/gravitee-api-management/pull/3805)
- fix: ignore author picture for api promotions
### [fix: search for subscribers in logs in an api context [3793]](https://github.com/gravitee-io/gravitee-api-management/pull/3793)
- fix: search for subscribers in logs in an api context
### [fix: markdown sanitization should be activated by default. [3795]](https://github.com/gravitee-io/gravitee-api-management/pull/3795)
- fix: markdown sanitization should be activated by default.
### [Fix and improve V1 to V2 conversion [3765]](https://github.com/gravitee-io/gravitee-api-management/pull/3765)
- fix: use conditional policies to convert a V1 API
- fix: security policy migration
### [fix: escaped search query when searching for a context path [3761]](https://github.com/gravitee-io/gravitee-api-management/pull/3761)
- fix: escaped search query when searching for a context path
### [Apply default role if user is matching no role mapping [3725]](https://github.com/gravitee-io/gravitee-api-management/pull/3725)
- fix: apply default role if user is matching no role mapping
### [fix: vertx thread blocked during api promotion [3746]](https://github.com/gravitee-io/gravitee-api-management/pull/3746)
- fix: split api promotion process
### [Export all subscriptions matching filters instead of only the displayed ones [3745]](https://github.com/gravitee-io/gravitee-api-management/pull/3745)
- fix: export all subscriptions instead of only the displayed ones
### [Handle Dynamic Properties for API not in DEFAULT environment [3740]](https://github.com/gravitee-io/gravitee-api-management/pull/3740)
- fix: handle Dynamic Properties for API not in DEFAULT environment
### [Bump `gravitee-tracer-jaeger` to `1.2.1` [3727]](https://github.com/gravitee-io/gravitee-api-management/pull/3727)
- fix: bump `gravitee-tracer-jaeger` to `1.2.1`

</details>

## Jira issues

[See all Jira issues for 3.18.x version](https://gravitee.atlassian.net/jira/software/c/projects/APIM/issues/?jql=project%20%3D%20%22APIM%22%20and%20fixVersion%20%3D%203.18.23%20and%20status%20%3D%20Done%20ORDER%20BY%20created%20DESC)
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://graviteedocs.blob.core.windows.net/release-apim-3-18-23/index.html)
<!-- UI placeholder end -->
