### PR TITLE
[APIM] Add changelog for new 3.19.12 release

### DIFF
--- a/pages/apim/3.x/changelog/changelog-3.19.adoc
+++ b/pages/apim/3.x/changelog/changelog-3.19.adoc
@@ -13,6 +13,47 @@ For upgrade instructions, please refer to https://docs.gravitee.io/apim/3.x/apim
 
 // <DO NOT REMOVE THIS COMMENT - ANCHOR FOR FUTURE RELEASES>
  
+== APIM - 3.19.12 (2023-04-28)
+
+=== Gateway
+
+* OutOfMemory when calling the Prometheus endpoint https://github.com/gravitee-io/issues/issues/8976[#8976]
+* Gateway fail to connect to Jaeger secured with TLS https://github.com/gravitee-io/issues/issues/9021[#9021]
+
+=== API
+
+* API Search returns a lexical error when using `/` https://github.com/gravitee-io/issues/issues/8753[#8753]
+* In DEFAULT mode, the operator EQUALS should not consider the path `/foo/:bar` like `/foo/.*` https://github.com/gravitee-io/issues/issues/8945[#8945]
+* APIs logs available to any API publisher https://github.com/gravitee-io/issues/issues/8968[#8968]
+* Event loop blocked when updating dynamic properties take a while https://github.com/gravitee-io/issues/issues/8969[#8969]
+* No default role applied for users if a Condition for a Role Mapping is evaluated as false https://github.com/gravitee-io/issues/issues/8971[#8971]
+* Plan policies are lost during API migration to design studio https://github.com/gravitee-io/issues/issues/8981[#8981]
+* AE Connector can't define proxy settings in 1.0.0 https://github.com/gravitee-io/issues/issues/9001[#9001]
+* Dynamic properties are not working on APIs not in DEFAULT environment https://github.com/gravitee-io/issues/issues/9018[#9018]
+* User with "USER" role can access APIs subscription approval https://github.com/gravitee-io/issues/issues/9022[#9022]
+* Improve API v1 (Path based) to API v2 (Flow based) conversion https://github.com/gravitee-io/issues/issues/9036[#9036]
+* Markdown sanitization activated by default
+
+=== Console
+
+* Missing readonly state on some inputs based on role's permissions  https://github.com/gravitee-io/issues/issues/7223[#7223]
+* "Export as CSV" on Subscriptions only export displayed values https://github.com/gravitee-io/issues/issues/8965[#8965]
+* Unable to filter APIs logs by application name https://github.com/gravitee-io/issues/issues/8995[#8995]
+* Prevent defining API Primary owner members in group in User mode https://github.com/gravitee-io/issues/issues/9020[#9020]
+
+=== Portal
+
+* Doc homepage does not load correctly when navigating to another API https://github.com/gravitee-io/issues/issues/8145[#8145]
+* API Picture not displayed on Application page https://github.com/gravitee-io/issues/issues/8749[#8749]
+* Performance issue of the portal-api https://github.com/gravitee-io/issues/issues/9023[#9023]
+
+=== Other
+
+* Cannot retrieve scheme (http/https) and port in Groovy policy, missing getters... https://github.com/gravitee-io/issues/issues/9007[#9007]
+* API properties can not be accessed in Javascript Policy https://github.com/gravitee-io/issues/issues/9010[#9010]
+* Policy SSL Enforcement too restrictive regex https://github.com/gravitee-io/issues/issues/9029[#9029]
+
+ 
 == APIM - 3.19.11 (2023-04-07)
 
 === API


### PR DESCRIPTION

# New APIM version 3.19.12 has been released
📝 You can modify the changelog template online [here](https://github.com/gravitee-io/gravitee-docs/edit/release-apim-3.19.12/pages/apim/3.x/changelog/changelog-3.19.adoc)

Here is some information to help with the writing:

## Pull requests
<details>
  <summary>See all Pull Requests</summary>

### [[3.19.x] fix: compute application apis subscribers links [3826]](https://github.com/gravitee-io/gravitee-api-management/pull/3826)
- fix: compute application apis subscribers links
### [[3.19.x] Bump policies and gravitee-node [3815]](https://github.com/gravitee-io/gravitee-api-management/pull/3815)
- fix: bump `gravitee-policy-request-validation` to `1.13.1`
- fix: bump `gravitee-policy-ssl-enforcement` to `1.2.3`
- fix: bump `gravitee-node` to `1.25.6`
### [[3.19.x] remove author picture from api promotion [3810]](https://github.com/gravitee-io/gravitee-api-management/pull/3810)
- fix: ignore author picture for api promotions
### [[3.19.x] fix: search for subscribers in logs in an api context [3804]](https://github.com/gravitee-io/gravitee-api-management/pull/3804)
- fix: search for subscribers in logs in an api context
### [[3.19.x] fix: markdown sanitization should be activated by default. [3799]](https://github.com/gravitee-io/gravitee-api-management/pull/3799)
- fix: markdown sanitization should be activated by default.
### [[3.19.x] Fix and improve V1 to V2 conversion [3790]](https://github.com/gravitee-io/gravitee-api-management/pull/3790)
- fix: use conditional policies to convert a V1 API
### [[3.19.x] fix: escaped search query when searching for a context path [3778]](https://github.com/gravitee-io/gravitee-api-management/pull/3778)
- fix: escaped search query when searching for a context path
### [[3.19.x] Apply default role if user is matching no role mapping [3772]](https://github.com/gravitee-io/gravitee-api-management/pull/3772)
- fix: apply default role if user is matching no role mapping
### [feat: add resource to set api definition context [3748]](https://github.com/gravitee-io/gravitee-api-management/pull/3748)
- feat: add resource to set api definition context
### [Improve Portal performances [3731]](https://github.com/gravitee-io/gravitee-api-management/pull/3731)
- perf: avoid fetching list when retrieving api metrics
- fix: index apis and applications groups using proper field name
- perf: remove n+1 selects from jdbc applications
- perf: optimize application ids retrieval
- fix: fix the create-index.js script
- fix: add a method to get ref id without loading the whole object
- fix: display APIs before loading all the metrics
### [fix: security policy migration [3757]](https://github.com/gravitee-io/gravitee-api-management/pull/3757)
- fix: security policy migration
### [[3.19.x] Export all subscriptions matching filters instead of only the displayed ones [3752]](https://github.com/gravitee-io/gravitee-api-management/pull/3752)
- fix: export all subscriptions instead of only the displayed ones
### [fix: vertx thread blocked during api promotion [ 3.19.x ] [3755]](https://github.com/gravitee-io/gravitee-api-management/pull/3755)
- fix: split api promotion process
### [[3.19.x] Handle Dynamic Properties for API not in DEFAULT environment [3744]](https://github.com/gravitee-io/gravitee-api-management/pull/3744)
- fix: handle Dynamic Properties for API not in DEFAULT environment
### [[3.19.x] Bump `gravitee-tracer-jaeger` to `1.2.1` [3729]](https://github.com/gravitee-io/gravitee-api-management/pull/3729)
- fix: bump `gravitee-tracer-jaeger` to `1.2.1`
### [[3.19.x] Handle Dynamic Properties for APIs not in DEFAULT environment [3721]](https://github.com/gravitee-io/gravitee-api-management/pull/3721)
- fix: handle Dynamic Properties for API not in DEFAULT environment
### [[3.19.x] fix: prevent adding an API PO in a group in user mode [3713]](https://github.com/gravitee-io/gravitee-api-management/pull/3713)
- fix: prevent adding an API PO in a group in user mode
### [[3.19.x] Bump `alert-engine-connectors-ws` to `1.1.0` [3709]](https://github.com/gravitee-io/gravitee-api-management/pull/3709)
- fix: bump `alert-engine-connectors-ws` to `1.1.0`
### [[3.19.x] fix: filter tasks when users does not have any membership [3697]](https://github.com/gravitee-io/gravitee-api-management/pull/3697)
- fix: filter tasks when users does not have any membership
### [[3.19.x] fix: find api accross all environments in dynamic properties updater [3668]](https://github.com/gravitee-io/gravitee-api-management/pull/3668)
- fix: find api accross all environments in dynamic properties updater
### [[3.19.x] fix: remove api-gateway-definition-u permission from api endpoints page [3675]](https://github.com/gravitee-io/gravitee-api-management/pull/3675)
- fix: remove api-gateway-definition-u permission from api endpoints page
### [[3.19.x] Reload API info and doc after an API search  [3673]](https://github.com/gravitee-io/gravitee-api-management/pull/3673)
- fix: reload API info and doc after an API search
- fix: display back button in API page only if needed
### [[3.19.x] Bump `json-smart` (to check Snyk integration is working fine) [3653]](https://github.com/gravitee-io/gravitee-api-management/pull/3653)
- fix: bump `json-smart` to `2.4.9`
### [[3.19.x] Rewrite Dynamic Properties service to avoid blocking the event loop [3641]](https://github.com/gravitee-io/gravitee-api-management/pull/3641)
- feat: define dynamic properties max pool size based on nb of processors
- fix: replace HttpProvider's name with a relevant one
- fix: rewrite Dynamic Properties service to avoid blocking the event loop
### [[3.19.x] fix: notification permission [3640]](https://github.com/gravitee-io/gravitee-api-management/pull/3640)
- fix: notification permission
### [fix: remove slash from path param regex 3.19.x [3633]](https://github.com/gravitee-io/gravitee-api-management/pull/3633)
- fix: remove slash from path param regex
### [[3.19.x] fix: display logs of authorized resources only [3626]](https://github.com/gravitee-io/gravitee-api-management/pull/3626)
- fix: display logs of authorized resources only
### [[3.19.x] Bump policies: JavaScript, Groovy, Circuit Breaker [3617]](https://github.com/gravitee-io/gravitee-api-management/pull/3617)
- fix: bump `policy-circuit-breaker` to `1.1.4`
- fix: bump `policy-groovy` to `2.3.0`
- fix: bump `policy-javascript` to `1.2.0`
### [UI permissions - 3.19.x [3606]](https://github.com/gravitee-io/gravitee-api-management/pull/3606)
- fix: api members
- fix: api notification
- fix: application global settings fix permission
- fix: fix permission in endpoint page
### [fix: don't rely on args to determine location - 3.19.x [3598]](https://github.com/gravitee-io/gravitee-api-management/pull/3598)
- fix: don't rely on args to determine location

</details>

## Jira issues

[See all Jira issues for 3.19.x version](https://gravitee.atlassian.net/jira/software/c/projects/APIM/issues/?jql=project%20%3D%20%22APIM%22%20and%20fixVersion%20%3D%203.19.12%20and%20status%20%3D%20Done%20ORDER%20BY%20created%20DESC)
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://graviteedocs.blob.core.windows.net/release-apim-3-19-12/index.html)
<!-- UI placeholder end -->
