### PR TITLE
[APIM] Add changelog for new 3.20.6 release

### DIFF
--- a/pages/apim/3.x/changelog/changelog-3.20.adoc
+++ b/pages/apim/3.x/changelog/changelog-3.20.adoc
@@ -13,6 +13,40 @@ For upgrade instructions, please refer to https://docs.gravitee.io/apim/3.x/apim
 
 // <DO NOT REMOVE THIS COMMENT - ANCHOR FOR FUTURE RELEASES>
  
+== APIM - 3.20.6 (2023-04-28)
+
+=== Gateway
+
+* OutOfMemory when calling the Prometheus endpoint https://github.com/gravitee-io/issues/issues/8976[#8976]
+* Gateway fail to connect to Jaeger secured with TLS https://github.com/gravitee-io/issues/issues/9021[#9021]
+
+=== API
+
+* API Search returns a lexical error when using `/` https://github.com/gravitee-io/issues/issues/8753[#8753]
+* No default role applied for users if a Condition for a Role Mapping is evaluated as false https://github.com/gravitee-io/issues/issues/8971[#8971]
+* Plan policies are lost during API migration to design studio https://github.com/gravitee-io/issues/issues/8981[#8981]
+* Dynamic properties are not working on APIs not in DEFAULT environment https://github.com/gravitee-io/issues/issues/9018[#9018]
+* User with "USER" role can access APIs subscription approval https://github.com/gravitee-io/issues/issues/9022[#9022]
+* Improve API v1 (Path based) to API v2 (Flow based) conversion https://github.com/gravitee-io/issues/issues/9036[#9036]
+* Markdown sanitization activated by default
+
+=== Console
+
+* "Export as CSV" on Subscriptions only export displayed values https://github.com/gravitee-io/issues/issues/8965[#8965]
+* Unable to filter API's logs by application name https://github.com/gravitee-io/issues/issues/8995[#8995]
+* Prevent defining API Primary owner members in group in User mode https://github.com/gravitee-io/issues/issues/9020[#9020]
+
+=== Portal
+
+* API Picture not displayed on Application page https://github.com/gravitee-io/issues/issues/8749[#8749]
+* Performance issue of the portal-api https://github.com/gravitee-io/issues/issues/9023[#9023]
+
+=== Other
+
+* Request Validation policy hangs in certain conditions https://github.com/gravitee-io/issues/issues/8347[#8347]
+* Policy SSL Enforcement too restrictive regex https://github.com/gravitee-io/issues/issues/9029[#9029]
+
+ 
 == APIM - 3.20.5 (2023-04-14)
 
 === Gateway


### PR DESCRIPTION

# New APIM version 3.20.6 has been released
📝 You can modify the changelog template online [here](https://github.com/gravitee-io/gravitee-docs/edit/release-apim-3.20.6/pages/apim/3.x/changelog/changelog-3.20.adoc)

Here is some information to help with the writing:

## Pull requests
<details>
  <summary>See all Pull Requests</summary>

### [[3.20.x] fix: compute application apis subscribers links [3825]](https://github.com/gravitee-io/gravitee-api-management/pull/3825)
- fix: compute application apis subscribers links
### [[3.20.x] Bump policies and gravitee-node [3816]](https://github.com/gravitee-io/gravitee-api-management/pull/3816)
- fix: bump `gravitee-policy-request-validation` to `1.13.1`
- fix: bump `gravitee-policy-ssl-enforcement` to `1.2.3`
- fix: bump `gravitee-node` to `2.0.7`
### [[3.20.x] remove author picture from api promotion [3809]](https://github.com/gravitee-io/gravitee-api-management/pull/3809)
- fix: ignore author picture for api promotions
### [[3.20.x] fix: search for subscribers in logs in an api context [3803]](https://github.com/gravitee-io/gravitee-api-management/pull/3803)
- fix: search for subscribers in logs in an api context
### [[3.20.x] fix: markdown sanitization should be activated by default. [3798]](https://github.com/gravitee-io/gravitee-api-management/pull/3798)
- fix: markdown sanitization should be activated by default.
### [[3.20.x] Fix and improve V1 to V2 conversion [3789]](https://github.com/gravitee-io/gravitee-api-management/pull/3789)
- fix: use conditional policies to convert a V1 API
### [feat: add resource to set api definition context [3747]](https://github.com/gravitee-io/gravitee-api-management/pull/3747)
- feat: add resource to set api definition context
### [[3.20.x] fix: escaped search query when searching for a context path [3777]](https://github.com/gravitee-io/gravitee-api-management/pull/3777)
- fix: escaped search query when searching for a context path
### [[3.20.x] Apply default role if user is matching no role mapping [3771]](https://github.com/gravitee-io/gravitee-api-management/pull/3771)
- fix: apply default role if user is matching no role mapping
### [[3.20.x] fix: security policy migration [3764]](https://github.com/gravitee-io/gravitee-api-management/pull/3764)
- fix: security policy migration
### [[3.20.x] Improve Portal performances [3768]](https://github.com/gravitee-io/gravitee-api-management/pull/3768)
- perf: avoid fetching list when retrieving api metrics
- fix: index apis and applications groups using proper field name
- perf: remove n+1 selects from jdbc applications
- perf: optimize application ids retrieval
- fix: fix the create-index.js script
- fix: add a method to get ref id without loading the whole object
- fix: display APIs before loading all the metrics
### [[3.20.x] fix: vertx thread blocked during api promotion [3758]](https://github.com/gravitee-io/gravitee-api-management/pull/3758)
- fix: split api promotion process
### [[3.20.x] Export all subscriptions matching filters instead of only the displayed ones [3751]](https://github.com/gravitee-io/gravitee-api-management/pull/3751)
- fix: export all subscriptions instead of only the displayed ones
### [[3.20.x] Handle Dynamic Properties for API not in DEFAULT environment [3743]](https://github.com/gravitee-io/gravitee-api-management/pull/3743)
- fix: handle Dynamic Properties for API not in DEFAULT environment
### [[3.20.x] Bump `gravitee-tracer-jaeger` to `1.2.1` [3728]](https://github.com/gravitee-io/gravitee-api-management/pull/3728)
- fix: bump `gravitee-tracer-jaeger` to `1.2.1`
### [[3.20.x] Handle Dynamic Properties for APIs not in DEFAULT environment [3720]](https://github.com/gravitee-io/gravitee-api-management/pull/3720)
- fix: handle Dynamic Properties for API not in DEFAULT environment
### [[3.20.x] fix: prevent adding an API PO in a group in user mode [3712]](https://github.com/gravitee-io/gravitee-api-management/pull/3712)
- fix: prevent adding an API PO in a group in user mode
### [[3.20.x] fix: filter tasks when users does not have any membership [3696]](https://github.com/gravitee-io/gravitee-api-management/pull/3696)
- fix: filter tasks when users does not have any membership

</details>

## Jira issues

[See all Jira issues for 3.20.x version](https://gravitee.atlassian.net/jira/software/c/projects/APIM/issues/?jql=project%20%3D%20%22APIM%22%20and%20fixVersion%20%3D%203.20.6%20and%20status%20%3D%20Done%20ORDER%20BY%20created%20DESC)
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://graviteedocs.blob.core.windows.net/release-apim-3-20-6/index.html)
<!-- UI placeholder end -->
