### PR TITLE
[APIM] Add changelog for new 3.20.7 release

### DIFF
--- a/pages/apim/3.x/changelog/changelog-3.20.adoc
+++ b/pages/apim/3.x/changelog/changelog-3.20.adoc
@@ -13,6 +13,27 @@ For upgrade instructions, please refer to https://docs.gravitee.io/apim/3.x/apim
 
 // <DO NOT REMOVE THIS COMMENT - ANCHOR FOR FUTURE RELEASES>
  
+== APIM - 3.20.7 (2023-05-05)
+
+=== API
+
+* Open Source Edition license issue when deploying Gravitee on Kubernetes using helm charts https://github.com/gravitee-io/issues/issues/8659[#8659]
+* API picture is removed when rollback is done https://github.com/gravitee-io/issues/issues/8801[#8801]
+* LDAP configuration with multi Orgs https://github.com/gravitee-io/issues/issues/8892[#8892]
+* API promotion not working with JDBC database https://github.com/gravitee-io/issues/issues/9033[#9033]
+* Dictionary Fields Not Visible to Users Without System Admin Organization Role https://github.com/gravitee-io/issues/issues/9038[#9038]
+* Login issues when role mapping is null https://github.com/gravitee-io/issues/issues/9040[#9040]
+
+=== Console
+
+* Focus lost after typing 1 character in fields of API's property https://github.com/gravitee-io/issues/issues/8802[#8802]
+* Unable to search application with its id https://github.com/gravitee-io/issues/issues/8996[#8996]
+
+=== Portal
+
+* When a page for API has long name, it appears indented in the page selection https://github.com/gravitee-io/issues/issues/7575[#7575]
+
+ 
 == APIM - 3.20.6 (2023-04-28)
 
 === Gateway


### PR DESCRIPTION

# New APIM version 3.20.7 has been released
📝 You can modify the changelog template online [here](https://github.com/gravitee-io/gravitee-docs/edit/release-apim-3.20.7/pages/apim/3.x/changelog/changelog-3.20.adoc)

Here is some information to help with the writing:

## Pull requests
<details>
  <summary>See all Pull Requests</summary>

### [[3.20.x] fix(console): add hash to get api picture & background [3895]](https://github.com/gravitee-io/gravitee-api-management/pull/3895)
- fix(console): add hash to get api picture & background
### [fix: bump gravitee-node to fix OS license check issue [3886]](https://github.com/gravitee-io/gravitee-api-management/pull/3886)
- fix: bump gravitee-node to fix OS license check issue
### [[3.20.x] fix(portal): bump ui-component to keep name text aline left when is long string [3884]](https://github.com/gravitee-io/gravitee-api-management/pull/3884)
- fix(portal): bump ui-component to keep name text aline left when is long string
### [[3.20.x] Handle null value in role mapping [3870]](https://github.com/gravitee-io/gravitee-api-management/pull/3870)
- fix: handle null value in role mapping
### [[3.20.x] fix(console): keep existing api picture / background on rollback if e… [3866]](https://github.com/gravitee-io/gravitee-api-management/pull/3866)
- fix(console): keep existing api picture / background on rollback if exist
### [[3.20.x] Add config to set `referral` when using a LDAP IdP [3862]](https://github.com/gravitee-io/gravitee-api-management/pull/3862)
- fix: add config to set referral when using LDAP
### [[3.20.x] fix(console): fix a focus bug when editing properties [3850]](https://github.com/gravitee-io/gravitee-api-management/pull/3850)
- fix(console): fix a focus bug when editing properties
### [[3.20.x] fix: check correct permission to get dictionary [3842]](https://github.com/gravitee-io/gravitee-api-management/pull/3842)
- fix: check correct permission to get dictionary https://gravitee.atlassian.net/browse/APIM-1565 https://github.com/gravitee-io/issues/issues/9038
### [[3.20.x] feat(console): application search can be done by application id [3846]](https://github.com/gravitee-io/gravitee-api-management/pull/3846)
- feat(console): application search can be done by application id

</details>

## Jira issues

[See all Jira issues for 3.20.x version](https://gravitee.atlassian.net/jira/software/c/projects/APIM/issues/?jql=project%20%3D%20%22APIM%22%20and%20fixVersion%20%3D%203.20.7%20and%20status%20%3D%20Done%20ORDER%20BY%20created%20DESC)
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://graviteedocs.blob.core.windows.net/release-apim-3-20-7/index.html)
<!-- UI placeholder end -->
