### PR TITLE
[APIM] Add changelog for new 3.20.8 release

### DIFF
--- a/pages/apim/3.x/changelog/changelog-3.20.adoc
+++ b/pages/apim/3.x/changelog/changelog-3.20.adoc
@@ -13,6 +13,12 @@ For upgrade instructions, please refer to https://docs.gravitee.io/apim/3.x/apim
 
 // <DO NOT REMOVE THIS COMMENT - ANCHOR FOR FUTURE RELEASES>
  
+== APIM - 3.20.8 (2023-05-05)
+
+=== Other
+
+* Encoding issue with the cache policy https://github.com/gravitee-io/issues/issues/8561[#8561]
+ 
 == APIM - 3.20.7 (2023-05-05)
 
 === API


### PR DESCRIPTION

# New APIM version 3.20.8 has been released
📝 You can modify the changelog template online [here](https://github.com/gravitee-io/gravitee-docs/edit/release-apim-3.20.8/pages/apim/3.x/changelog/changelog-3.20.adoc)

Here is some information to help with the writing:

## Pull requests
<details>
  <summary>See all Pull Requests</summary>

### [[3.20.x] Bump `gravitee-policy-cache` to `1.16.0` [3900]](https://github.com/gravitee-io/gravitee-api-management/pull/3900)
- fix: bump `gravitee-policy-cache` to `1.16.0`

</details>

## Jira issues

[See all Jira issues for 3.20.x version](https://gravitee.atlassian.net/jira/software/c/projects/APIM/issues/?jql=project%20%3D%20%22APIM%22%20and%20fixVersion%20%3D%203.20.8%20and%20status%20%3D%20Done%20ORDER%20BY%20created%20DESC)
