### PR TITLE
[APIM] Add changelog for new 3.20.9 release

### DIFF
--- a/pages/apim/3.x/changelog/changelog-3.20.adoc
+++ b/pages/apim/3.x/changelog/changelog-3.20.adoc
@@ -13,6 +13,22 @@ For upgrade instructions, please refer to https://docs.gravitee.io/apim/3.x/apim
 
 // <DO NOT REMOVE THIS COMMENT - ANCHOR FOR FUTURE RELEASES>
  
+== APIM - 3.20.9 (2023-05-15)
+
+=== API
+
+* Error with the link for documentation, after api creation wizard https://github.com/gravitee-io/issues/issues/7242[#7242]
+* Method pathParameters() in groovy policy gives null value https://github.com/gravitee-io/issues/issues/8854[#8854]
+* PathParameter are not working https://github.com/gravitee-io/issues/issues/8921[#8921]
+* Improve performance of endpoint to list plans on the Portal API https://github.com/gravitee-io/issues/issues/9042[#9042]
+* Problem in Loading Plan for some APIs   https://github.com/gravitee-io/issues/issues/9044[#9044]
+
+=== Console
+
+* Cursor wrongly placed in markdown editor https://github.com/gravitee-io/issues/issues/7254[#7254]
+* China does not show correctly on default Geo dashboard https://github.com/gravitee-io/issues/issues/8230[#8230]
+* Changing the default logo in the Theme has no effect  https://github.com/gravitee-io/issues/issues/8882[#8882]
+
 == APIM - 3.20.8 (2023-05-05)
 
 === Other


### PR DESCRIPTION

# New APIM version 3.20.9 has been released
📝 You can modify the changelog template online [here](https://github.com/gravitee-io/gravitee-docs/edit/release-apim-3.20.9/pages/apim/3.x/changelog/changelog-3.20.adoc)

Here is some information to help with the writing:

## Pull requests
<details>
  <summary>See all Pull Requests</summary>

### [[3.20.x] fix: remove requirement on repository CACHE scope [3959]](https://github.com/gravitee-io/gravitee-api-management/pull/3959)
- fix: remove requirement on repository CACHE scope
### [fix: add path parameters resolution for v2 api [3.20] [3942]](https://github.com/gravitee-io/gravitee-api-management/pull/3942)
- fix: add path parameters resolution for v2 api
### [[3.20.x] Update ToastUI [3953]](https://github.com/gravitee-io/gravitee-api-management/pull/3953)
- feat(console): upgrade toast-ui to 3.2.2
### [[3.20.x] fix(rest-api): improve getUserMember performance [3947]](https://github.com/gravitee-io/gravitee-api-management/pull/3947)
- fix(rest-api): improve getUserMember performance
### [feat(console): remove Organization Theme settings [3916]](https://github.com/gravitee-io/gravitee-api-management/pull/3916)
- feat(console): remove Organization Theme settings
### [Bump elasticsearch reporter and common lib to support ES8 [3917]](https://github.com/gravitee-io/gravitee-api-management/pull/3917)
- fix: bump elasticsearch reporter and common lib to support ES8
### [[3.20.x] fix(portal-api): remove unnecessary apiService.findPublishedByUser [3913]](https://github.com/gravitee-io/gravitee-api-management/pull/3913)
- fix(portal-api): remove unnecessary apiService.findPublishedByUser
### [[3.20.x] Bump `@gravitee/ui-components` to `3.39.5` [3920]](https://github.com/gravitee-io/gravitee-api-management/pull/3920)
- fix: bump `@gravitee/ui-components` to `3.39.5`
### [[3.20.x] fix(console): use right env var to get settings.documentation url [3924]](https://github.com/gravitee-io/gravitee-api-management/pull/3924)
- fix(console): use right env var to get settings.documentation url

</details>

## Jira issues

[See all Jira issues for 3.20.x version](https://gravitee.atlassian.net/jira/software/c/projects/APIM/issues/?jql=project%20%3D%20%22APIM%22%20and%20fixVersion%20%3D%203.20.9%20and%20status%20%3D%20Done%20ORDER%20BY%20created%20DESC)
