### PR TITLE
[APIM] Add changelog for new 3.19.14 release

### DIFF
--- a/pages/apim/3.x/changelog/changelog-3.19.adoc
+++ b/pages/apim/3.x/changelog/changelog-3.19.adoc
@@ -13,6 +13,26 @@ For upgrade instructions, please refer to https://docs.gravitee.io/apim/3.x/apim
 
 // <DO NOT REMOVE THIS COMMENT - ANCHOR FOR FUTURE RELEASES>
  
+== APIM - 3.19.14 (2023-05-15)
+
+=== API
+
+* Error with the link for documentation, after api creation wizard https://github.com/gravitee-io/issues/issues/7242[#7242]
+* Method pathParameters() in groovy policy gives null value https://github.com/gravitee-io/issues/issues/8854[#8854]
+* PathParameter are not working https://github.com/gravitee-io/issues/issues/8921[#8921]
+* Improve performance of endpoint to list plans on the Portal API https://github.com/gravitee-io/issues/issues/9042[#9042]
+* Problem in Loading Plan for some APIs   https://github.com/gravitee-io/issues/issues/9044[#9044]
+
+=== Console
+
+* Cursor wrongly placed in markdown editor https://github.com/gravitee-io/issues/issues/7254[#7254]
+* China does not show correctly on default Geo dashboard https://github.com/gravitee-io/issues/issues/8230[#8230]
+
+=== Other
+
+* Encoding issue with the cache policy https://github.com/gravitee-io/issues/issues/8561[#8561]
+
+ 
 == APIM - 3.19.13 (2023-05-05)
 
 === API


### PR DESCRIPTION

# New APIM version 3.19.14 has been released
📝 You can modify the changelog template online [here](https://github.com/gravitee-io/gravitee-docs/edit/release-apim-3.19.14/pages/apim/3.x/changelog/changelog-3.19.adoc)

Here is some information to help with the writing:

## Pull requests
<details>
  <summary>See all Pull Requests</summary>

### [fix: remove requirement on repository CACHE scope [3909]](https://github.com/gravitee-io/gravitee-api-management/pull/3909)
- fix: remove requirement on repository CACHE scope
### [fix: add path parameters resolution for v2 api [3.19] [3934]](https://github.com/gravitee-io/gravitee-api-management/pull/3934)
- fix: add path parameters resolution for v2 api
### [[3.19.x] Update ToastUI [3954]](https://github.com/gravitee-io/gravitee-api-management/pull/3954)
- feat(console): upgrade toast-ui to 3.2.2
### [[3.19.x] fix(rest-api): improve getUserMember performance [3948]](https://github.com/gravitee-io/gravitee-api-management/pull/3948)
- fix(rest-api): improve getUserMember performance
### [[3.19.x] Bump `@gravitee/ui-components` to `3.39.5` [3921]](https://github.com/gravitee-io/gravitee-api-management/pull/3921)
- fix: bump `@gravitee/ui-components` to `3.39.5`
### [[3.19.x] fix(console): use right env var to get settings.documentation url [3926]](https://github.com/gravitee-io/gravitee-api-management/pull/3926)
- fix(console): use right env var to get settings.documentation url
### [[3.19.x] fix(portal-api): remove unnecessary apiService.findPublishedByUser [3914]](https://github.com/gravitee-io/gravitee-api-management/pull/3914)
- fix(portal-api): remove unnecessary apiService.findPublishedByUser
### [[3.19.x] Bump `gravitee-policy-cache` to `1.16.0` [3901]](https://github.com/gravitee-io/gravitee-api-management/pull/3901)
- fix: bump `gravitee-policy-cache` to `1.16.0`

</details>

## Jira issues

[See all Jira issues for 3.19.x version](https://gravitee.atlassian.net/jira/software/c/projects/APIM/issues/?jql=project%20%3D%20%22APIM%22%20and%20fixVersion%20%3D%203.19.14%20and%20status%20%3D%20Done%20ORDER%20BY%20created%20DESC)
