### PR TITLE
[APIM] Add changelog for new 3.18.25 release

### DIFF
--- a/pages/apim/3.x/changelog/changelog-3.18.adoc
+++ b/pages/apim/3.x/changelog/changelog-3.18.adoc
@@ -13,6 +13,26 @@ For upgrade instructions, please refer to https://docs.gravitee.io/apim/3.x/apim
 
 // <DO NOT REMOVE THIS COMMENT - ANCHOR FOR FUTURE RELEASES>
  
+== APIM - 3.18.25 (2023-05-15)
+
+=== API
+
+* Error with the link for documentation, after api creation wizard https://github.com/gravitee-io/issues/issues/7242[#7242]
+* Method pathParameters() in groovy policy gives null value https://github.com/gravitee-io/issues/issues/8854[#8854]
+* PathParameter are not working https://github.com/gravitee-io/issues/issues/8921[#8921]
+* Improve performance of endpoint to list plans on the Portal API https://github.com/gravitee-io/issues/issues/9042[#9042]
+* Problem in Loading Plan for some APIs   https://github.com/gravitee-io/issues/issues/9044[#9044]
+
+=== Console
+
+* Cursor wrongly placed in markdown editor https://github.com/gravitee-io/issues/issues/7254[#7254]
+* China does not show correctly on default Geo dashboard https://github.com/gravitee-io/issues/issues/8230[#8230]
+
+=== Other
+
+* Encoding issue with the cache policy https://github.com/gravitee-io/issues/issues/8561[#8561]
+
+ 
 == APIM - 3.18.24 (2023-05-05)
 
 === API


### PR DESCRIPTION

# New APIM version 3.18.25 has been released
📝 You can modify the changelog template online [here](https://github.com/gravitee-io/gravitee-docs/edit/release-apim-3.18.25/pages/apim/3.x/changelog/changelog-3.18.adoc)

Here is some information to help with the writing:

## Pull requests
<details>
  <summary>See all Pull Requests</summary>

### [[3.18] Add path parameters resolution for v2 api  [3932]](https://github.com/gravitee-io/gravitee-api-management/pull/3932)
- fix: add path parameters resolution for v2 api
- fix(sdk): improve error logging and keyless policy
### [Update ToastUI [3839]](https://github.com/gravitee-io/gravitee-api-management/pull/3839)
- feat(console): upgrade toast-ui to 3.2.2
### [fix(rest-api): improve getUserMember performance [3937]](https://github.com/gravitee-io/gravitee-api-management/pull/3937)
- fix(rest-api): improve getUserMember performance
### [fix(console): use right env var to get settings.documentation url [3910]](https://github.com/gravitee-io/gravitee-api-management/pull/3910)
- fix(console): use right env var to get settings.documentation url
### [Bump `@gravitee/ui-components` to `3.39.5` [3915]](https://github.com/gravitee-io/gravitee-api-management/pull/3915)
- fix: bump `@gravitee/ui-components` to `3.39.5`
### [fix: remove requirement on repository CACHE type [3908]](https://github.com/gravitee-io/gravitee-api-management/pull/3908)
- fix: remove requirement on repository CACHE type
### [fix(portal-api): remove unnecessary apiService.findPublishedByUser [3902]](https://github.com/gravitee-io/gravitee-api-management/pull/3902)
- fix(portal-api): remove unnecessary apiService.findPublishedByUser
### [Bump `gravitee-policy-cache` to `1.16.0` [3897]](https://github.com/gravitee-io/gravitee-api-management/pull/3897)
- fix: bump `gravitee-policy-cache` to `1.16.0`

</details>

## Jira issues

[See all Jira issues for 3.18.x version](https://gravitee.atlassian.net/jira/software/c/projects/APIM/issues/?jql=project%20%3D%20%22APIM%22%20and%20fixVersion%20%3D%203.18.25%20and%20status%20%3D%20Done%20ORDER%20BY%20created%20DESC)
