### PR TITLE
[APIM] Add changelog for new 3.19.15 release

### DIFF
--- a/pages/apim/3.x/changelog/changelog-3.19.adoc
+++ b/pages/apim/3.x/changelog/changelog-3.19.adoc
@@ -13,6 +13,28 @@ For upgrade instructions, please refer to https://docs.gravitee.io/apim/3.x/apim
 
 // <DO NOT REMOVE THIS COMMENT - ANCHOR FOR FUTURE RELEASES>
  
+== APIM - 3.19.15 (2023-05-26)
+
+=== API
+
+* Notification using email from metadata are not working  https://github.com/gravitee-io/issues/issues/9030[#9030]
+* Plan Selection Rules Not Migrating with API Version Upgrade https://github.com/gravitee-io/issues/issues/9032[#9032]
+* Application list is showing also archived applications even if we request not to https://github.com/gravitee-io/issues/issues/9050[#9050]
+* Pagination of Application endpoint is broken on last page https://github.com/gravitee-io/issues/issues/9052[#9052]
+
+=== Console
+
+* Drag & Drop is not working in policy studio with Firefox 111+ https://github.com/gravitee-io/issues/issues/8970[#8970]
+
+=== Portal
+
+* Impossible to contact the owner of API on developer portal when the owner is a group https://github.com/gravitee-io/issues/issues/6616[#6616]
+
+=== Other
+
+* Validate request policy does not work with APIM <3.20 https://github.com/gravitee-io/issues/issues/9045[#9045]
+
+ 
 == APIM - 3.19.14 (2023-05-15)
 
 === API


### PR DESCRIPTION

# New APIM version 3.19.15 has been released
📝 You can modify the changelog template online [here](https://github.com/gravitee-io/gravitee-docs/edit/release-apim-3.19.15/pages/apim/3.x/changelog/changelog-3.19.adoc)

Here is some information to help with the writing:

## Pull requests
<details>
  <summary>See all Pull Requests</summary>

### [fix: remove closed plans in debug mode [4059]](https://github.com/gravitee-io/gravitee-api-management/pull/4059)
- fix: remove closed plans in debug mode
### [fix: set flowMode when convert DebugApi [4061]](https://github.com/gravitee-io/gravitee-api-management/pull/4061)
- fix: set flowMode when convert DebugApi
### [fix: resolve findAccessibleApiIdsForUser in ApiAuthorizationService [4049]](https://github.com/gravitee-io/gravitee-api-management/pull/4049)
- fix: resolve findAccessibleApiIdsForUser in ApiAuthorizationService
### [[3.19.x] fix: apply the status filter when getting the list of applications [4046]](https://github.com/gravitee-io/gravitee-api-management/pull/4046)
- fix: apply the status filter when getting the list of applications
### [[3.19.x] Allow to search api to all the one accessible for the application subscription - for no admin user [4013]](https://github.com/gravitee-io/gravitee-api-management/pull/4013)
- feat(console): allow to search api to all the one accessible for the application subscription
- feat(rest-api): add `manageOnly` QueryParam to POST `_search/_paged`
### [[3.19.x] Enable use of API's metadata as email recipient [4002]](https://github.com/gravitee-io/gravitee-api-management/pull/4002)
- fix: enable use of API's metadata as email recipient
### [[3.19.x] fix(design): resolve drag and drop on FF linux [4005]](https://github.com/gravitee-io/gravitee-api-management/pull/4005)
- fix(design): resolve drag and drop on FF linux
### [[3.19.x] fix: pagination data in applications [3998]](https://github.com/gravitee-io/gravitee-api-management/pull/3998)
- fix: pagination data in applications
### [fix: remove circular dependency between services [3989]](https://github.com/gravitee-io/gravitee-api-management/pull/3989)
- fix: remove circular dependency between services
### [[3.19.x] Migrate all the fields of the API plans [3988]](https://github.com/gravitee-io/gravitee-api-management/pull/3988)
- fix: migrate all the fields of the API plans
### [[3.19.x] fix: resolve support email recipient when PO is a group [3976]](https://github.com/gravitee-io/gravitee-api-management/pull/3976)
- fix: resolve support email recipient when PO is a group

</details>

## Jira issues

[See all Jira issues for 3.19.x version](https://gravitee.atlassian.net/jira/software/c/projects/APIM/issues/?jql=project%20%3D%20%22APIM%22%20and%20fixVersion%20%3D%203.19.15%20and%20status%20%3D%20Done%20ORDER%20BY%20created%20DESC)
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://graviteedocs.blob.core.windows.net/release-apim-3-19-15/index.html)
<!-- UI placeholder end -->
