### PR TITLE
[APIM] Add changelog for new 3.20.10 release

### DIFF
--- a/pages/apim/3.x/changelog/changelog-3.20.adoc
+++ b/pages/apim/3.x/changelog/changelog-3.20.adoc
@@ -13,6 +13,28 @@ For upgrade instructions, please refer to https://docs.gravitee.io/apim/3.x/apim
 
 // <DO NOT REMOVE THIS COMMENT - ANCHOR FOR FUTURE RELEASES>
  
+== APIM - 3.20.10 (2023-05-26)
+
+=== API
+
+* Notification using email from metadata are not working  https://github.com/gravitee-io/issues/issues/9030[#9030]
+* Plan Selection Rules Not Migrating with API Version Upgrade https://github.com/gravitee-io/issues/issues/9032[#9032]
+* Application list is showing also archived applications even if we request not to https://github.com/gravitee-io/issues/issues/9050[#9050]
+* Pagination of Application endpoint is broken on last page https://github.com/gravitee-io/issues/issues/9052[#9052]
+
+=== Console
+
+* Drag & Drop is not working in policy studio with Firefox 111+ https://github.com/gravitee-io/issues/issues/8970[#8970]
+
+=== Portal
+
+* Impossible to contact the owner of API on developer portal when the owner is a group https://github.com/gravitee-io/issues/issues/6616[#6616]
+
+=== Other
+
+* Validate request policy does not work with APIM <3.20 https://github.com/gravitee-io/issues/issues/9045[#9045]
+
+ 
 == APIM - 3.20.9 (2023-05-15)
 
 === API


### PR DESCRIPTION

# New APIM version 3.20.10 has been released
📝 You can modify the changelog template online [here](https://github.com/gravitee-io/gravitee-docs/edit/release-apim-3.20.10/pages/apim/3.x/changelog/changelog-3.20.adoc)

Here is some information to help with the writing:

## Pull requests
<details>
  <summary>See all Pull Requests</summary>

### [[3.20.x] fix: remove closed plans in debug mode [4071]](https://github.com/gravitee-io/gravitee-api-management/pull/4071)
- fix: remove closed plans in debug mode
### [[3.20.x] fix: set flowMode when convert DebugApi [4067]](https://github.com/gravitee-io/gravitee-api-management/pull/4067)
- fix: set flowMode when convert DebugApi
### [feat: support elasticsearch version 8 [4006]](https://github.com/gravitee-io/gravitee-api-management/pull/4006)
- feat: support elasticsearch version 8
### [[3.20.x] fix: apply the status filter when getting the list of applications [4048]](https://github.com/gravitee-io/gravitee-api-management/pull/4048)
- fix: apply the status filter when getting the list of applications
### [[3.20.x] fix: resolve findAccessibleApiIdsForUser in ApiAuthorizationService [4052]](https://github.com/gravitee-io/gravitee-api-management/pull/4052)
- fix: resolve findAccessibleApiIdsForUser in ApiAuthorizationService
### [[3.20.x] Allow to search api to all the one accessible for the application subscription - for no admin user [4039]](https://github.com/gravitee-io/gravitee-api-management/pull/4039)
- feat(console): allow to search api to all the one accessible for the application subscription
- feat(rest-api): add `manageOnly` QueryParam to POST `_search/_paged`
### [[3.20.x] Enable use of API's metadata as email recipient [4024]](https://github.com/gravitee-io/gravitee-api-management/pull/4024)
- fix: enable use of API's metadata as email recipient
### [[3.20.x] fix(design): resolve drag and drop on FF linux [4004]](https://github.com/gravitee-io/gravitee-api-management/pull/4004)
- fix(design): resolve drag and drop on FF linux
### [[3.20.x] fix: pagination data in applications [3997]](https://github.com/gravitee-io/gravitee-api-management/pull/3997)
- fix: pagination data in applications
### [fix: resolve support email recipient when PO is a group  [3991]](https://github.com/gravitee-io/gravitee-api-management/pull/3991)
- fix: remove circular dependency between services
- fix: resolve support email recipient when PO is a group
### [[3.20.x] Migrate all the fields of the API plans [3987]](https://github.com/gravitee-io/gravitee-api-management/pull/3987)
- fix: migrate all the fields of the API plans

</details>

## Jira issues

[See all Jira issues for 3.20.x version](https://gravitee.atlassian.net/jira/software/c/projects/APIM/issues/?jql=project%20%3D%20%22APIM%22%20and%20fixVersion%20%3D%203.20.10%20and%20status%20%3D%20Done%20ORDER%20BY%20created%20DESC)
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://graviteedocs.blob.core.windows.net/release-apim-3-20-10/index.html)
<!-- UI placeholder end -->
