### PR TITLE
fix: bump AE version to 2.1.2

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -128,7 +128,7 @@ products:
     ee:
       version: 3.21.0
   ae:
-    version: 2.1.1
+    version: 2.1.2
     name: Gravitee.io Alert Engine (AE)
 
 asciidoc: {}


### PR DESCRIPTION
This PR bumps the version of AE 2.1.2
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://graviteedocs.blob.core.windows.net/ae-2-1-2/index.html)
<!-- UI placeholder end -->
