### PR TITLE
[APIM] Add changelog for new 3.20.11 release

### DIFF
--- a/pages/apim/3.x/changelog/changelog-3.20.adoc
+++ b/pages/apim/3.x/changelog/changelog-3.20.adoc
@@ -13,6 +13,32 @@ For upgrade instructions, please refer to https://docs.gravitee.io/apim/3.x/apim
 
 // <DO NOT REMOVE THIS COMMENT - ANCHOR FOR FUTURE RELEASES>
  
+== APIM - 3.20.11 (2023-06-08)
+
+=== Gateway
+
+* Invalid property in the config file example https://github.com/gravitee-io/issues/issues/9061[#9061]
+* Error when client is closing the connection before the Gateway handled the response from backend (jupiter activated) https://github.com/gravitee-io/issues/issues/9073[#9073]
+* APIs that have special characters in path parameter do not work https://github.com/gravitee-io/issues/issues/9081[#9081]
+
+=== API
+
+* Enhance dynamic dictionary logging https://github.com/gravitee-io/issues/issues/8973[#8973]
+* Keyless plan is still useable in DEBUG mode even after being closed https://github.com/gravitee-io/issues/issues/9006[#9006]
+* Improve performance of endpoint to list pages on the Portal API https://github.com/gravitee-io/issues/issues/9053[#9053]
+
+=== Console
+
+* Environment Settings Inaccessible to Local Users Without Admin Organization Role  https://github.com/gravitee-io/issues/issues/9070[#9070]
+* Error message when trying to open "Backend services" with documentation panel open https://github.com/gravitee-io/issues/issues/9071[#9071]
+* Application Log API Filter Displays Unsubscribed APIs https://github.com/gravitee-io/issues/issues/9080[#9080]
+
+=== Other
+
+* Duplicate `annotations` field in deployment in the Helm Chart https://github.com/gravitee-io/issues/issues/9082[#9082]
+
+
+ 
 == APIM - 3.20.10 (2023-05-26)
 
 === API


### PR DESCRIPTION

# New APIM version 3.20.11 has been released
📝 You can modify the changelog template online [here](https://github.com/gravitee-io/gravitee-docs/edit/release-apim-3.20.11/pages/apim/3.x/changelog/changelog-3.20.adoc)
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://graviteedocs.blob.core.windows.net/release-apim-3-20-11/index.html)
<!-- UI placeholder end -->
