### PR TITLE
[APIM] Add changelog for new 3.20.13 release

### DIFF
--- a/pages/apim/3.x/changelog/changelog-3.20.adoc
+++ b/pages/apim/3.x/changelog/changelog-3.20.adoc
@@ -13,6 +13,38 @@ For upgrade instructions, please refer to https://docs.gravitee.io/apim/3.x/apim
 
 // <DO NOT REMOVE THIS COMMENT - ANCHOR FOR FUTURE RELEASES>
  
+== APIM - 3.20.13 (2023-07-06)
+
+=== API
+
+* API level email notifications not being sent when owner is a group https://github.com/gravitee-io/issues/issues/9079[#9079]
+* Internal Server Exception 500: when trying to access api or app from url https://github.com/gravitee-io/issues/issues/9089[#9089]
+* API search is returning APIs with irrelevant sorting when searching with multiple terms https://github.com/gravitee-io/issues/issues/9095[#9095]
+* Deploy an API regardless of its origin https://github.com/gravitee-io/issues/issues/9103[#9103]
+* Gateway not able to connect to ES 8 https://github.com/gravitee-io/issues/issues/9105[#9105]
+* Promotion not working with API containing lots of documentation or images https://github.com/gravitee-io/issues/issues/9110[#9110]
+
+=== Console
+
+* APIM UI Settings Permissions  https://github.com/gravitee-io/issues/issues/9077[#9077]
+
+=== Portal
+
+* User Role Has Ability To Update Application Metadata in Portal UI https://github.com/gravitee-io/issues/issues/9031[#9031]
+
+=== Helm Chart
+    
+* Gateway ratelimit configuration missing mongo truststore https://github.com/gravitee-io/issues/issues/9067[#9067]
+* `api` section in config map not applied due to wrong indentation https://github.com/gravitee-io/issues/issues/9120[#9120]
+
+=== Other
+
+* Cannot change Content-Type from Groovy policy failure result https://github.com/gravitee-io/issues/issues/9066[#9066]
+* URL encoded path not usable in Dynamic Routing policy https://github.com/gravitee-io/issues/issues/9107[#9107]
+* gravitee-policy-oauth2: TokenIntrospectionResult does not support `scp` for key in JWT https://github.com/gravitee-io/issues/issues/9114[#9114]
+
+
+ 
 == APIM - 3.20.12 (2023-06-23)
 
 === Gateway


### PR DESCRIPTION

# New APIM version 3.20.13 has been released
📝 You can modify the changelog template online [here](https://github.com/gravitee-io/gravitee-docs/edit/release-apim-3.20.13/pages/apim/3.x/changelog/changelog-3.20.adoc)
