### PR TITLE
[APIM] Add changelog for new 3.19.19 release

### DIFF
--- a/pages/apim/3.x/changelog/changelog-3.19.adoc
+++ b/pages/apim/3.x/changelog/changelog-3.19.adoc
@@ -13,6 +13,28 @@ For upgrade instructions, please refer to https://docs.gravitee.io/apim/3.x/apim
 
 // <DO NOT REMOVE THIS COMMENT - ANCHOR FOR FUTURE RELEASES>
  
+== APIM - 3.19.19 (2023-07-20)
+
+=== Gateway
+
+* Allow to increase websocket max frame size and max message size in `gravitee.yaml` https://github.com/gravitee-io/issues/issues/6751[#6751]
+* No plan selected when using JWT with selection rule and keyless plans https://github.com/gravitee-io/issues/issues/9127[#9127]
+
+=== API
+
+* Errors when removing used Tenants https://github.com/gravitee-io/issues/issues/7842[#7842]
+* Unable to validate a subscription if app name is longer than 64 characters https://github.com/gravitee-io/issues/issues/9115[#9115]
+
+=== Console
+
+* Markdown documentation disappears if the syntax is wrong https://github.com/gravitee-io/issues/issues/7230[#7230]
+
+=== Portal
+
+* Markdown Editor Page Link Syntax Shows as Plain Text in Portal https://github.com/gravitee-io/issues/issues/9129[#9129]
+
+
+ 
 == APIM - 3.19.18 (2023-07-06)
 
 === API


### PR DESCRIPTION

# New APIM version 3.19.19 has been released
📝 You can modify the changelog template online [here](https://github.com/gravitee-io/gravitee-docs/edit/release-apim-3.19.19/pages/apim/3.x/changelog/changelog-3.19.adoc)
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://graviteedocs.blob.core.windows.net/release-apim-3-19-19/index.html)
<!-- UI placeholder end -->
