### PR TITLE
[APIM] Add changelog for new 4.0.1 release

### DIFF
--- a/_data/sidebars/apim_3_x_sidebar.yml
+++ b/_data/sidebars/apim_3_x_sidebar.yml
@@ -191,115 +191,115 @@ entries:
       - title: Configuration Guide
         output: web
         folderitems:
-         - title: Introduction
-           output: web
-           url: /apim/3.x/apim_configurationguide.html
-           subfolders:
-            - title: Configure APIM Gateway
-              output: web
-              subfolderitems:
-               - title: General Configuration
-                 output: web
-                 url: /apim/3.x/apim_installguide_gateway_configuration.html
-               - title: Internal API
-                 output: web
-                 url: /apim/3.x/apim_installguide_gateway_technical_api.html
-               - title: Metrics
-                 output: web
-                 url: /apim/3.x/apim_installguide_gateway_metrics.html
-               - title: Enable OpenTracing
-                 output: web
-                 url: /apim/3.x/apim_enable_opentracing_with_jaeger.html
-               - title: OpenTracing in Docker
-                 output: web
-                 url: /apim/3.x/apim_opentracing_in_docker.html
-            - title: Configure APIM API
-              output: web
-              subfolderitems:
-               - title: General Configuration
-                 output: web
-                 url: /apim/3.x/apim_installguide_rest_apis_configuration.html
-               - title: Internal API
-                 output: web
-                 url: /apim/3.x/apim_installguide_rest_apis_technical_api.html
-               - title: Metrics
-                 output: web
-                 url: /apim/3.x/apim_installguide_rest_apis_metrics.html
-               - title: Security
-                 output: web
-                 url: /apim/3.x/apim_installguide_rest_apis_security.html
-            - title: Configure APIM Console
-              output: web
-              subfolderitems:
-               - title: General Configuration
-                 output: web
-                 url: /apim/3.x/apim_installguide_management_ui_configuration.html
-               - title: Dashboards
-                 output: web
-                 url: /apim/3.x/apim_installguide_dashboard_configuration.html
-            - title: Configure APIM Portal
-              output: web
-              subfolderitems:
-               - title: General Configuration
-                 output: web
-                 url: /apim/3.x/apim_installguide_portal_ui_configuration.html
-            - title: Configure Repositories
-              output: web
-              subfolderitems:
-               - title: Introduction
-                 output: web
-                 url: /apim/3.x/apim_installguide_repositories.html
-               - title: Elasticsearch
-                 output: web
-                 url: /apim/3.x/apim_installguide_repositories_elasticsearch.html
-               - title: MongoDB
-                 output: web
-                 url: /apim/3.x/apim_installguide_repositories_mongodb.html
-               - title: JDBC
-                 output: web
-                 url: /apim/3.x/apim_installguide_repositories_jdbc.html
-               - title: Redis
-                 output: web
-                 url: /apim/3.x/apim_installguide_repositories_redis.html
-            - title: Configure Authentication
-              output: web
-              subfolderitems:
-               - title: Introduction
-                 output: web
-                 url: /apim/3.x/apim_installguide_authentication.html
-               - title: Connect with In-Memory Users
-                 output: web
-                 url: /apim/3.x/apim_installguide_authentication_inmemory.html
-               - title: Connect with LDAP/Active Directory
-                 output: web
-                 url: /apim/3.x/apim_installguide_authentication_ldap.html
-               - title: Connect with APIM Repository
-                 output: web
-                 url: /apim/3.x/apim_installguide_authentication_apim.html
-               - title: Connect with Gravitee.io Access Management
-                 output: web
-                 url: /apim/3.x/apim_installguide_authentication_graviteeam.html
-               - title: Connect with GitHub
-                 output: web
-                 url: /apim/3.x/apim_installguide_authentication_github.html
-               - title: Connect with Google
-                 output: web
-                 url: /apim/3.x/apim_installguide_authentication_google.html
-               - title: Connect with Keycloak
-                 output: web
-                 url: /apim/3.x/apim_installguide_authentication_keycloak.html
-         - title: Configure Reporters
-           output: web
-           url: /apim/3.x/apim_installguide_reporters.html
-         - title: Configure Cache
-           output: web
-           url: /apim/3.x/apim_installguide_cache.html
-         - title: Configure Notifications
-           output: web
-           url: /apim/3.x/apim_installguide_configuration_notifications.html
-         - title: Configure Dictionaries
-           output: web
-           url: /apim/3.x/apim_installguide_configuration_dictionaries.html
+          - title: Introduction
+            output: web
+            url: /apim/3.x/apim_configurationguide.html
+            subfolders:
+              - title: Configure APIM Gateway
+                output: web
+                subfolderitems:
+                  - title: General Configuration
+                    output: web
+                    url: /apim/3.x/apim_installguide_gateway_configuration.html
+                  - title: Internal API
+                    output: web
+                    url: /apim/3.x/apim_installguide_gateway_technical_api.html
+                  - title: Metrics
+                    output: web
+                    url: /apim/3.x/apim_installguide_gateway_metrics.html
+                  - title: Enable OpenTracing
+                    output: web
+                    url: /apim/3.x/apim_enable_opentracing_with_jaeger.html
+                  - title: OpenTracing in Docker
+                    output: web
+                    url: /apim/3.x/apim_opentracing_in_docker.html
+              - title: Configure APIM API
+                output: web
+                subfolderitems:
+                  - title: General Configuration
+                    output: web
+                    url: /apim/3.x/apim_installguide_rest_apis_configuration.html
+                  - title: Internal API
+                    output: web
+                    url: /apim/3.x/apim_installguide_rest_apis_technical_api.html
+                  - title: Metrics
+                    output: web
+                    url: /apim/3.x/apim_installguide_rest_apis_metrics.html
+                  - title: Security
+                    output: web
+                    url: /apim/3.x/apim_installguide_rest_apis_security.html
+              - title: Configure APIM Console
+                output: web
+                subfolderitems:
+                  - title: General Configuration
+                    output: web
+                    url: /apim/3.x/apim_installguide_management_ui_configuration.html
+                  - title: Dashboards
+                    output: web
+                    url: /apim/3.x/apim_installguide_dashboard_configuration.html
+              - title: Configure APIM Portal
+                output: web
+                subfolderitems:
+                  - title: General Configuration
+                    output: web
+                    url: /apim/3.x/apim_installguide_portal_ui_configuration.html
+              - title: Configure Repositories
+                output: web
+                subfolderitems:
+                  - title: Introduction
+                    output: web
+                    url: /apim/3.x/apim_installguide_repositories.html
+                  - title: Elasticsearch
+                    output: web
+                    url: /apim/3.x/apim_installguide_repositories_elasticsearch.html
+                  - title: MongoDB
+                    output: web
+                    url: /apim/3.x/apim_installguide_repositories_mongodb.html
+                  - title: JDBC
+                    output: web
+                    url: /apim/3.x/apim_installguide_repositories_jdbc.html
+                  - title: Redis
+                    output: web
+                    url: /apim/3.x/apim_installguide_repositories_redis.html
+              - title: Configure Authentication
+                output: web
+                subfolderitems:
+                  - title: Introduction
+                    output: web
+                    url: /apim/3.x/apim_installguide_authentication.html
+                  - title: Connect with In-Memory Users
+                    output: web
+                    url: /apim/3.x/apim_installguide_authentication_inmemory.html
+                  - title: Connect with LDAP/Active Directory
+                    output: web
+                    url: /apim/3.x/apim_installguide_authentication_ldap.html
+                  - title: Connect with APIM Repository
+                    output: web
+                    url: /apim/3.x/apim_installguide_authentication_apim.html
+                  - title: Connect with Gravitee.io Access Management
+                    output: web
+                    url: /apim/3.x/apim_installguide_authentication_graviteeam.html
+                  - title: Connect with GitHub
+                    output: web
+                    url: /apim/3.x/apim_installguide_authentication_github.html
+                  - title: Connect with Google
+                    output: web
+                    url: /apim/3.x/apim_installguide_authentication_google.html
+                  - title: Connect with Keycloak
+                    output: web
+                    url: /apim/3.x/apim_installguide_authentication_keycloak.html
+          - title: Configure Reporters
+            output: web
+            url: /apim/3.x/apim_installguide_reporters.html
+          - title: Configure Cache
+            output: web
+            url: /apim/3.x/apim_installguide_cache.html
+          - title: Configure Notifications
+            output: web
+            url: /apim/3.x/apim_installguide_configuration_notifications.html
+          - title: Configure Dictionaries
+            output: web
+            url: /apim/3.x/apim_installguide_configuration_dictionaries.html
       - title: API Publisher Guide
         output: web
         folderitems:
@@ -377,39 +377,39 @@ entries:
               - title: Resources
                 output: web
                 subfolderitems:
-                - title: Introduction
-                  output: web
-                  url: /apim/3.x/apim_resources_overview.html
-                - title: Cache
-                  output: web
-                  url: /apim/3.x/apim_resources_cache.html
-                - title: Cache Redis
-                  output: web
-                  url: /apim/3.x/apim_resources_cache_redis.html
-                - title: OAuth2 - Gravitee.io Access Management
-                  output: web
-                  url: /apim/3.x/apim_resources_oauth2_am.html
-                - title: OAuth2 - Generic Authorization Server
-                  output: web
-                  url: /apim/3.x/apim_resources_oauth2_generic.html
+                  - title: Introduction
+                    output: web
+                    url: /apim/3.x/apim_resources_overview.html
+                  - title: Cache
+                    output: web
+                    url: /apim/3.x/apim_resources_cache.html
+                  - title: Cache Redis
+                    output: web
+                    url: /apim/3.x/apim_resources_cache_redis.html
+                  - title: OAuth2 - Gravitee.io Access Management
+                    output: web
+                    url: /apim/3.x/apim_resources_oauth2_am.html
+                  - title: OAuth2 - Generic Authorization Server
+                    output: web
+                    url: /apim/3.x/apim_resources_oauth2_generic.html
               - title: Design Studio Guide
                 output: web
                 subfolderitems:
-                - title: Introduction
-                  output: web
-                  url: /apim/3.x/apim_publisherguide_design_studio_overview.html
-                - title: Migrate to Design Studio
-                  output: web
-                  url: /apim/3.x/apim_publisherguide_design_studio_migrate.html
-                - title: Design Your API Flows
-                  output: web
-                  url: /apim/3.x/apim_publisherguide_design_studio_create.html
-                - title: Try it! Mode
-                  output: web
-                  url: /apim/3.x/apim_publisherguide_design_studio_try_it.html
-                - title: Debug Mode
-                  output: web
-                  url: /apim/3.x/apim_publisherguide_design_studio_debug_mode.html
+                  - title: Introduction
+                    output: web
+                    url: /apim/3.x/apim_publisherguide_design_studio_overview.html
+                  - title: Migrate to Design Studio
+                    output: web
+                    url: /apim/3.x/apim_publisherguide_design_studio_migrate.html
+                  - title: Design Your API Flows
+                    output: web
+                    url: /apim/3.x/apim_publisherguide_design_studio_create.html
+                  - title: Try it! Mode
+                    output: web
+                    url: /apim/3.x/apim_publisherguide_design_studio_try_it.html
+                  - title: Debug Mode
+                    output: web
+                    url: /apim/3.x/apim_publisherguide_design_studio_debug_mode.html
               - title: Documentation
                 output: web
                 subfolderitems:
@@ -456,18 +456,18 @@ entries:
       - title: API Consumer Guide
         output: web
         folderitems:
-         - title: Introduction
-           output: web
-           url: /apim/3.x/apim_consumerguide_portal.html
-         - title: Create an Account
-           output: web
-           url: /apim/3.x/apim_consumerguide_create_account.html
-         - title: Manage Applications
-           output: web
-           url: /apim/3.x/apim_consumerguide_manage_applications.html
-         - title: Subscribe to APIs
-           output: web
-           url: /apim/3.x/apim_consumerguide_subscribe.html
+          - title: Introduction
+            output: web
+            url: /apim/3.x/apim_consumerguide_portal.html
+          - title: Create an Account
+            output: web
+            url: /apim/3.x/apim_consumerguide_create_account.html
+          - title: Manage Applications
+            output: web
+            url: /apim/3.x/apim_consumerguide_manage_applications.html
+          - title: Subscribe to APIs
+            output: web
+            url: /apim/3.x/apim_consumerguide_subscribe.html
 
       - title: Administration Guide
         output: web
@@ -659,7 +659,6 @@ entries:
             output: web
             url: /apim/3.x/apim_policies_xslt.html
 
-
       - title: Kubernetes Operator
         output: web
         folderitems:
@@ -699,7 +698,7 @@ entries:
                     url: /apim/3.x/apim_kubernetes_operator_user_guide_api_definition.html
                   - title: How to use the Application resource
                     output: web
-                    url: /apim/3.x/apim_kubernetes_operator_user_guide_application.html             
+                    url: /apim/3.x/apim_kubernetes_operator_user_guide_application.html
                   - title: How to reuse API resources with the GKO [NEW]
                     output: web
                     url: /apim/3.x/apim_kubernetes_operator_user_guide_reusable_resources.html
@@ -769,51 +768,51 @@ entries:
               - title: Tutorials
                 output: web
                 subfolderitems:
-                - title: Introduction
-                  output: web
-                  url: /apim/3.x/event_native_tutorials.html
-                - title: Setting up Postman
-                  output: web
-                  url: /apim/3.x/event_native_tutorials_postman.html
-                - title: Installing APIM
-                  output: web
-                  url: /apim/3.x/event_native_tutorials_apim.html
-                - title: Custom Install
-                  output: web
-                  url: /apim/3.x/event_native_tutorials_apim_custom.html
-                - title: Installing AKHQ
-                  output: web
-                  url: /apim/3.x/event_native_tutorials_akhq.html
-                - title: Installing HiveMQ
-                  output: web
-                  url: /apim/3.x/event_native_tutorials_hivemq.html
-                - title: Kafka and HTTP
-                  output: web
-                  url: /apim/3.x/event_native_tutorials_kafka_http.html
-                - title: Kafka Advanced, HTTP, and Confluent Cloud
-                  output: web
-                  url: /apim/3.x/event_native_tutorials_kafka_advanced_http_confluentcloud.html
-                - title: Kafka and SSE
-                  output: web
-                  url: /apim/3.x/event_native_tutorials_kafka_sse.html
-                - title: Kafka and Webhooks
-                  output: web
-                  url: /apim/3.x/event_native_tutorials_kafka_webhooks.html
-                - title: Kafka and Websockets
-                  output: web
-                  url: /apim/3.x/event_native_tutorials_kafka_websockets.html
-                - title: MQTT and HTTP
-                  output: web
-                  url: /apim/3.x/event_native_tutorials_mqtt_http.html
-                - title: MQTT and SSE
-                  output: web
-                  url: /apim/3.x/event_native_tutorials_mqtt_sse.html
-                - title: MQTT and Webhooks
-                  output: web
-                  url: /apim/3.x/event_native_tutorials_mqtt_webhooks.html
-                - title: MQTT and Websockets
-                  output: web
-                  url: /apim/3.x/event_native_tutorials_mqtt_websockets.html
+                  - title: Introduction
+                    output: web
+                    url: /apim/3.x/event_native_tutorials.html
+                  - title: Setting up Postman
+                    output: web
+                    url: /apim/3.x/event_native_tutorials_postman.html
+                  - title: Installing APIM
+                    output: web
+                    url: /apim/3.x/event_native_tutorials_apim.html
+                  - title: Custom Install
+                    output: web
+                    url: /apim/3.x/event_native_tutorials_apim_custom.html
+                  - title: Installing AKHQ
+                    output: web
+                    url: /apim/3.x/event_native_tutorials_akhq.html
+                  - title: Installing HiveMQ
+                    output: web
+                    url: /apim/3.x/event_native_tutorials_hivemq.html
+                  - title: Kafka and HTTP
+                    output: web
+                    url: /apim/3.x/event_native_tutorials_kafka_http.html
+                  - title: Kafka Advanced, HTTP, and Confluent Cloud
+                    output: web
+                    url: /apim/3.x/event_native_tutorials_kafka_advanced_http_confluentcloud.html
+                  - title: Kafka and SSE
+                    output: web
+                    url: /apim/3.x/event_native_tutorials_kafka_sse.html
+                  - title: Kafka and Webhooks
+                    output: web
+                    url: /apim/3.x/event_native_tutorials_kafka_webhooks.html
+                  - title: Kafka and Websockets
+                    output: web
+                    url: /apim/3.x/event_native_tutorials_kafka_websockets.html
+                  - title: MQTT and HTTP
+                    output: web
+                    url: /apim/3.x/event_native_tutorials_mqtt_http.html
+                  - title: MQTT and SSE
+                    output: web
+                    url: /apim/3.x/event_native_tutorials_mqtt_sse.html
+                  - title: MQTT and Webhooks
+                    output: web
+                    url: /apim/3.x/event_native_tutorials_mqtt_webhooks.html
+                  - title: MQTT and Websockets
+                    output: web
+                    url: /apim/3.x/event_native_tutorials_mqtt_websockets.html
           - title: Example Use Cases
             output: web
             url: /apim/3.x/event_native_apim_example_use_cases.html
@@ -842,3 +841,6 @@ entries:
           - title: Changelog 3.20
             output: web
             url: /apim/3.x/changelog-3.20.html
+          - title: Changelog 4.0
+            output: web
+            url: /apim/3.x/changelog-4.0.html

--- a/pages/apim/3.x/changelog/changelog-4.0.adoc
+++ b/pages/apim/3.x/changelog/changelog-4.0.adoc
@@ -1,0 +1,29 @@
+:page-sidebar: apim_3_x_sidebar
+:page-permalink: apim/3.x/changelog-4.0.html
+:page-folder: apim
+:page-toc: false
+:page-layout: apim3x
+
+= APIM 4.0 changelog
+
+For upgrade instructions, please refer to https://docs.gravitee.io/apim/3.x/apim_installguide_migration.html[APIM Migration Guide]
+
+*Important:* If you plan to skip versions when you upgrade, ensure that you read the version-specific upgrade notes for each intermediate version. You may be required to perform manual actions as part of the upgrade.
+
+// NOTE: Global 4.0 release info here
+
+// <DO NOT REMOVE THIS COMMENT - ANCHOR FOR FUTURE RELEASES>
+ 
+== APIM - 4.0.1 (2023-07-27)
+
+=== Gateway
+
+* Log exception parameter of execution failure https://github.com/gravitee-io/issues/issues/null[#null]
+
+=== API
+
+* Creating a plan on a v2 API leads to null values in the description https://github.com/gravitee-io/issues/issues/null[#null]
+* First API Export Causes API Desynchronization https://github.com/gravitee-io/issues/issues/null[#null]
+* Dashboard for analytics are shown from all environments https://github.com/gravitee-io/issues/issues/null[#null]
+
+


### PR DESCRIPTION

# New APIM version 4.0.1 has been released
📝 You can modify the changelog template online [here](https://github.com/gravitee-io/gravitee-docs/edit/release-apim-4.0.1/pages/apim/3.x/changelog/changelog-4.0.adoc)
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://graviteedocs.blob.core.windows.net/release-apim-4-0-1/index.html)
<!-- UI placeholder end -->
