### PR TITLE
[APIM] Add changelog for new 3.19.22 release

### DIFF
--- a/pages/apim/3.x/changelog/changelog-3.19.adoc
+++ b/pages/apim/3.x/changelog/changelog-3.19.adoc
@@ -13,6 +13,17 @@ For upgrade instructions, please refer to https://docs.gravitee.io/apim/3.x/apim
 
 // <DO NOT REMOVE THIS COMMENT - ANCHOR FOR FUTURE RELEASES>
  
+== APIM - 3.19.22 (2023-08-31)
+
+=== API
+
+* Primary owner can remove himself from application with management api https://github.com/gravitee-io/issues/issues/9171[#9171]
+
+=== Helm Chart
+
+* Add `podSecurityContext` to define a SecurityContext at deployment level https://github.com/gravitee-io/issues/issues/9209[#9209]
+
+ 
 == APIM - 3.19.21 (2023-08-18)
 
 === API


### PR DESCRIPTION

# New APIM version 3.19.22 has been released
📝 You can modify the changelog template online [here](https://github.com/gravitee-io/gravitee-docs/edit/release-apim-3.19.22/pages/apim/3.x/changelog/changelog-3.19.adoc)
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://graviteedocs.blob.core.windows.net/release-apim-3-19-22/index.html)
<!-- UI placeholder end -->
