### PR TITLE
[APIM] Add changelog for new 3.20.18 release

### DIFF
--- a/pages/apim/3.x/changelog/changelog-3.20.adoc
+++ b/pages/apim/3.x/changelog/changelog-3.20.adoc
@@ -13,6 +13,18 @@ For upgrade instructions, please refer to https://docs.gravitee.io/apim/3.x/apim
 
 // <DO NOT REMOVE THIS COMMENT - ANCHOR FOR FUTURE RELEASES>
  
+== APIM - 3.20.18 (2023-09-11)
+
+=== Gateway
+
+* Do not consider semicolon as query param separator https://github.com/gravitee-io/issues/issues/9131[#9131]
+
+=== Console
+
+* Restart UI Container leads to HTTP 301 https://github.com/gravitee-io/issues/issues/9186[#9186]
+
+
+ 
 == APIM - 3.20.17 (2023-08-31)
 
 === API


### PR DESCRIPTION

# New APIM version 3.20.18 has been released
📝 You can modify the changelog template online [here](https://github.com/gravitee-io/gravitee-docs/edit/release-apim-3.20.18/pages/apim/3.x/changelog/changelog-3.20.adoc)
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://graviteedocs.blob.core.windows.net/release-apim-3-20-18/index.html)
<!-- UI placeholder end -->
