### PR TITLE
[APIM] Add changelog for new 3.19.24 release

### DIFF
--- a/pages/apim/3.x/changelog/changelog-3.19.adoc
+++ b/pages/apim/3.x/changelog/changelog-3.19.adoc
@@ -12,7 +12,14 @@ For upgrade instructions, please refer to https://docs.gravitee.io/apim/3.x/apim
 // NOTE: Global 3.19 release info here
 
 // <DO NOT REMOVE THIS COMMENT - ANCHOR FOR FUTURE RELEASES>
- 
+
+== APIM - 3.19.24 (2023-09-14)
+
+=== API
+
+* Path with ":*" in path mappings is breaking down the environment https://github.com/gravitee-io/issues/issues/9214[#9214]
+
+
 == APIM - 3.19.23 (2023-09-11)
 
 === Gateway
@@ -24,7 +31,7 @@ For upgrade instructions, please refer to https://docs.gravitee.io/apim/3.x/apim
 * Restart UI Container leads to HTTP 301 https://github.com/gravitee-io/issues/issues/9186[#9186]
 
 
- 
+
 == APIM - 3.19.22 (2023-08-31)
 
 === API


### PR DESCRIPTION

# New APIM version 3.19.24 has been released
📝 You can modify the changelog template online [here](https://github.com/gravitee-io/gravitee-docs/edit/release-apim-3.19.24/pages/apim/3.x/changelog/changelog-3.19.adoc)
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://graviteedocs.blob.core.windows.net/release-apim-3-19-24/index.html)
<!-- UI placeholder end -->
