### PR TITLE
Change response code to 200 on closeApiPlan endpoint

### DIFF
--- a/apim/3.x/management-api/3.20/swagger.json
+++ b/apim/3.x/management-api/3.20/swagger.json
@@ -9568,7 +9568,7 @@
           }
         ],
         "responses": {
-          "204": {
+          "200": {
             "description": "Plan successfully closed",
             "content": {
               "application/json": {
@@ -30636,7 +30636,7 @@
           }
         ],
         "responses": {
-          "204": {
+          "200": {
             "description": "Plan successfully closed",
             "content": {
               "application/json": {


### PR DESCRIPTION
**Issue**

https://gravitee.atlassian.net/browse/APIM-3091
https://github.com/gravitee-io/issues/issues/9351

**Description**

Related to https://github.com/gravitee-io/gravitee-api-management/pull/5689
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://graviteedocs.blob.core.windows.net/apim-3091-response-code/index.html)
<!-- UI placeholder end -->
