### PR TITLE
[APIM] Add changelog for new 3.20.28 release

### DIFF
--- a/pages/apim/3.x/changelog/changelog-3.20.adoc
+++ b/pages/apim/3.x/changelog/changelog-3.20.adoc
@@ -13,6 +13,21 @@ For upgrade instructions, please refer to https://docs.gravitee.io/apim/3.x/apim
 
 // <DO NOT REMOVE THIS COMMENT - ANCHOR FOR FUTURE RELEASES>
  
+== APIM - 3.20.28 (2024-02-02)
+=== BugFixes
+==== Gateway
+
+* Timeout when connecting to websocket api using header Connection:Upgrade,Keep-Alive https://github.com/gravitee-io/issues/issues/9487[#9487]
+
+
+=== Improvements
+==== Gateway
+
+* Add API id in health check logs https://github.com/gravitee-io/issues/issues/9493[#9493]
+
+
+
+ 
 == APIM - 3.20.27 (2024-01-19)
 === BugFixes
 ==== Gateway


### PR DESCRIPTION

# New APIM version 3.20.28 has been released
📝 You can modify the changelog template online [here](https://github.com/gravitee-io/gravitee-docs/edit/release-apim-3.20.28/pages/apim/3.x/changelog/changelog-3.20.adoc)
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://graviteedocs.blob.core.windows.net/release-apim-3-20-28/index.html)
<!-- UI placeholder end -->
