### PR TITLE
[APIM] Add changelog for new 3.20.32 release

### DIFF
--- a/pages/apim/3.x/changelog/changelog-3.20.adoc
+++ b/pages/apim/3.x/changelog/changelog-3.20.adoc
@@ -13,6 +13,26 @@ For upgrade instructions, please refer to https://docs.gravitee.io/apim/3.x/apim
 
 // <DO NOT REMOVE THIS COMMENT - ANCHOR FOR FUTURE RELEASES>
  
+== APIM - 3.20.32 (2024-03-29)
+=== BugFixes
+==== Management API
+
+* Update import remove all members when a group is defined as a PO https://github.com/gravitee-io/issues/issues/9596[#9596]
+
+==== Other
+
+* [gravitee-policy-ipfiltering] DNS Lookup fails with some DNS server https://github.com/gravitee-io/issues/issues/9592[#9592]
+* [gravitee-resource-auth-provider-http] Timeout when authentication condition is failing https://github.com/gravitee-io/issues/issues/9611[#9611]
+
+
+=== Improvements
+==== Management API
+
+* Allow to configure KeepAliveTimeout for HTTP Endpoint https://github.com/gravitee-io/issues/issues/9541[#9541]
+
+
+
+ 
 == APIM - 3.20.31 (2024-03-21)
 === BugFixes
 ==== Gateway


### PR DESCRIPTION

# New APIM version 3.20.32 has been released
📝 You can modify the changelog template online [here](https://github.com/gravitee-io/gravitee-docs/edit/release-apim-3.20.32/pages/apim/3.x/changelog/changelog-3.20.adoc)
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://graviteedocs.blob.core.windows.net/release-apim-3-20-32/index.html)
<!-- UI placeholder end -->
